### PR TITLE
feat(series): replace chapter pagination with smooth scrollbar view

### DIFF
--- a/src/lib/components/series/ChapterList.svelte
+++ b/src/lib/components/series/ChapterList.svelte
@@ -6,46 +6,29 @@
   import type { Chapter } from '$lib/types'
 
   interface Props {
-    pageChapters:    Chapter[]
     sortedChapters:  Chapter[]
     viewMode:        'list' | 'grid'
     loadingChapters: boolean
     selectedIds:     Set<number>
     enqueueing:      Set<number>
-    chapterPage:     number
-    totalPages:      number
     onOpen:          (ch: Chapter, inProgress: boolean) => void
     onToggleSelect:  (id: number, e: MouseEvent | KeyboardEvent) => void
     onEnqueue:       (ch: Chapter, e: MouseEvent) => void
     onDeleteDownload:(id: number) => void
-    onPageChange:    (page: number) => void
-    onPageSizeChange:(n: number) => void
     buildCtxItems:   (ch: Chapter, idx: number) => MenuEntry[]
   }
 
   let {
-    pageChapters, sortedChapters, viewMode, loadingChapters,
-    selectedIds, enqueueing, chapterPage, totalPages,
+    sortedChapters, viewMode, loadingChapters,
+    selectedIds, enqueueing,
     onOpen, onToggleSelect, onEnqueue, onDeleteDownload,
-    onPageChange, onPageSizeChange, buildCtxItems,
+    buildCtxItems,
   }: Props = $props()
 
   let ctx: { x: number; y: number; chapter: Chapter; idx: number } | null = $state(null)
   let listEl: HTMLDivElement | null = $state(null)
 
   const hasSelection = $derived(selectedIds.size > 0)
-
-  $effect(() => {
-    if (!listEl || viewMode !== 'list') return
-    const ro = new ResizeObserver(([entry]) => {
-      const firstRow = listEl!.querySelector('.ch-row') as HTMLElement | null
-      const rowH = firstRow ? firstRow.offsetHeight : 37
-      const n = Math.max(1, Math.floor(entry.contentRect.height / rowH))
-      onPageSizeChange(n)
-    })
-    ro.observe(listEl)
-    return () => ro.disconnect()
-  })
 
   function chapterLongPress(node: HTMLElement, param: [Chapter, number]) {
     const [ch, idx] = param
@@ -79,6 +62,7 @@
     {#each sortedChapters as ch, i}
       {@const isGridSelected = selectedIds.has(ch.id)}
       <button
+        id={'ch-' + ch.id}
         class="grid-cell"
         class:read={ch.read}
         class:grid-selected={isGridSelected}
@@ -96,11 +80,11 @@
     {/each}
 
   {:else}
-    {#each pageChapters as ch}
-      {@const idxInSorted  = sortedChapters.indexOf(ch)}
+    {#each sortedChapters as ch, idxInSorted}
       {@const isSelected   = selectedIds.has(ch.id)}
       {@const chInProgress = !ch.read && (ch.lastPageRead ?? 0) > 0}
       <div
+        id={'ch-' + ch.id}
         role="button"
         tabindex="0"
         class="ch-row"
@@ -144,21 +128,18 @@
   {/if}
 </div>
 
-{#if totalPages > 1}
-  <div class="pagination-bottom">
-    <button class="page-btn" onclick={() => onPageChange(Math.max(1, chapterPage - 1))} disabled={chapterPage === 1}>← Prev</button>
-    <span class="page-num">{chapterPage} / {totalPages}</span>
-    <button class="page-btn" onclick={() => onPageChange(Math.min(totalPages, chapterPage + 1))} disabled={chapterPage === totalPages}>Next →</button>
-  </div>
-{/if}
-
 {#if ctx}
   <ContextMenu x={ctx.x} y={ctx.y} items={buildCtxItems(ctx.chapter, ctx.idx)} onClose={() => ctx = null} />
 {/if}
 
 <style>
-  .ch-list  { flex: 1; overflow: hidden; }
-  .ch-grid  { flex: 1; overflow: hidden; display: grid; grid-template-columns: repeat(auto-fill, minmax(42px, 1fr)); gap: 4px; padding: var(--sp-3); align-content: start; }
+  .ch-list  { flex: 1; overflow-y: auto; scrollbar-width: thin; scrollbar-color: var(--border-strong) transparent; }
+  .ch-grid  { flex: 1; overflow-y: auto; display: grid; grid-template-columns: repeat(auto-fill, minmax(42px, 1fr)); gap: 4px; padding: var(--sp-3); align-content: start; scrollbar-width: thin; scrollbar-color: var(--border-strong) transparent; }
+
+  .ch-list::-webkit-scrollbar, .ch-grid::-webkit-scrollbar { width: 6px; height: 6px; }
+  .ch-list::-webkit-scrollbar-track, .ch-grid::-webkit-scrollbar-track { background: transparent; }
+  .ch-list::-webkit-scrollbar-thumb, .ch-grid::-webkit-scrollbar-thumb { background: var(--border-strong); border-radius: 99px; }
+  .ch-list::-webkit-scrollbar-thumb:hover, .ch-grid::-webkit-scrollbar-thumb:hover { background: var(--text-faint); }
 
   .ch-row { display: flex; align-items: center; padding: 8px var(--sp-4); border-bottom: 1px solid var(--border-dim); cursor: pointer; transition: background var(--t-fast); gap: var(--sp-3); }
   .ch-row:hover { background: var(--bg-raised); }
@@ -206,10 +187,4 @@
   .grid-cell-skeleton { aspect-ratio: 1; border-radius: var(--radius-sm); }
   .grid-selected { background: var(--accent-muted) !important; border-color: var(--accent-dim) !important; }
   .grid-cell-check { position: absolute; inset: 0; display: flex; align-items: center; justify-content: center; font-size: 14px; color: var(--accent-fg); pointer-events: none; }
-
-  .pagination-bottom { display: flex; align-items: center; justify-content: center; gap: var(--sp-2); padding: var(--sp-3); border-top: 1px solid var(--border-dim); flex-shrink: 0; }
-  .page-btn { font-family: var(--font-ui); font-size: var(--text-xs); letter-spacing: var(--tracking-wide); padding: 4px 10px; border-radius: var(--radius-sm); border: 1px solid var(--border-dim); color: var(--text-faint); background: none; cursor: pointer; transition: color var(--t-base), border-color var(--t-base); }
-  .page-btn:hover:not(:disabled) { color: var(--text-muted); border-color: var(--border-strong); }
-  .page-btn:disabled { opacity: 0.3; cursor: default; }
-  .page-num { font-family: var(--font-ui); font-size: var(--text-xs); color: var(--text-faint); letter-spacing: var(--tracking-wide); }
 </style>

--- a/src/lib/components/series/SeriesActions.svelte
+++ b/src/lib/components/series/SeriesActions.svelte
@@ -35,7 +35,6 @@
     catsLoading:             boolean
     refreshing:              boolean
     onViewModeToggle:        () => void
-    onPageChange:            (page: number) => void
     onDownloadSelected:      () => void
     onDeleteSelected:        () => void
     onMarkSelectedRead:      (isRead: boolean) => void
@@ -60,7 +59,7 @@
     hasSelection, selectedCount, continueChapter,
     availableScanlators, scanlatorFilter, scanlatorBlacklist, scanlatorForce,
     allCategories, mangaCategories, catsLoading, refreshing,
-    onViewModeToggle, onPageChange, onDownloadSelected, onDeleteSelected,
+    onViewModeToggle, onDownloadSelected, onDeleteSelected,
     onMarkSelectedRead, onClearSelection, onEnqueueNext, onEnqueueMultiple,
     onDeleteAll, onRefresh, onToggleCategory, onCreateCategory,
     onSetScanlatorFilter, onSetScanlatorBlacklist, onSetScanlatorForce,
@@ -96,8 +95,7 @@
 
   function doJump() {
     if (!jumpChapter) return
-    const pageIdx = sortedChapters.indexOf(jumpChapter)
-    if (pageIdx >= 0) onPageChange(Math.floor(pageIdx / 25) + 1)
+    document.getElementById(`ch-${jumpChapter.id}`)?.scrollIntoView({ block: 'center', behavior: 'smooth' })
     jumpOpen = false; jumpInput = ''
   }
 
@@ -166,11 +164,11 @@
               <button
                 class="sort-option"
                 class:active={sortMode === val}
-                onclick={() => { onSortModeChange(val as ChapterSortMode); onPageChange(1); sortMenuOpen = false }}
+                onclick={() => { onSortModeChange(val as ChapterSortMode); sortMenuOpen = false }}
               >{label}</button>
             {/each}
             <div class="sort-divider"></div>
-            <button class="sort-option" onclick={() => { onSortDirChange(sortDir === 'desc' ? 'asc' : 'desc'); onPageChange(1); sortMenuOpen = false }}>
+            <button class="sort-option" onclick={() => { onSortDirChange(sortDir === 'desc' ? 'asc' : 'desc'); sortMenuOpen = false }}>
               {sortDir === 'desc' ? '↑ Ascending' : '↓ Descending'}
             </button>
           </div>
@@ -224,16 +222,16 @@
                 <button class="scan-filter-tab" class:scan-filter-tab-active={scanTab === 'block'}  onclick={() => scanTab = 'block'}>Block</button>
               </div>
               {#if scanTab === 'prefer' && scanlatorFilter.length > 0}
-                <button class="scan-filter-clear" onclick={() => { onSetScanlatorFilter([]); onSetScanlatorForce(false); onPageChange(1) }}>Clear</button>
+                <button class="scan-filter-clear" onclick={() => { onSetScanlatorFilter([]); onSetScanlatorForce(false) }}>Clear</button>
               {:else if scanTab === 'block' && scanlatorBlacklist.length > 0}
-                <button class="scan-filter-clear" onclick={() => { onSetScanlatorBlacklist([]); onPageChange(1) }}>Clear</button>
+                <button class="scan-filter-clear" onclick={() => { onSetScanlatorBlacklist([]) }}>Clear</button>
               {/if}
             </div>
             <div class="scan-filter-divider"></div>
             {#if scanTab === 'prefer'}
               <div class="scan-filter-force-row">
                 <span class="scan-filter-force-label" title="Hide chapters with no preferred group match, rather than falling back to any available group.">Enforce</span>
-                <button class="scan-force-toggle" class:scan-force-on={scanlatorForce} onclick={() => { onSetScanlatorForce(!scanlatorForce); onPageChange(1) }}>
+                <button class="scan-force-toggle" class:scan-force-on={scanlatorForce} onclick={() => { onSetScanlatorForce(!scanlatorForce) }}>
                   {scanlatorForce ? 'On' : 'Off'}
                 </button>
               </div>
@@ -243,7 +241,7 @@
                   class="scan-filter-item"
                   class:scan-filter-item-active={scanlatorFilter.includes(s)}
                   role="menuitem"
-                  onclick={() => { onSetScanlatorFilter(scanlatorFilter.includes(s) ? scanlatorFilter.filter(x => x !== s) : [...scanlatorFilter, s]); onPageChange(1) }}
+                  onclick={() => { onSetScanlatorFilter(scanlatorFilter.includes(s) ? scanlatorFilter.filter(x => x !== s) : [...scanlatorFilter, s]) }}
                 >
                   <span class="scan-filter-check" class:scan-filter-check-on={scanlatorFilter.includes(s)}>
                     {#if scanlatorFilter.includes(s)}<Check size={9} weight="bold" />{/if}
@@ -258,7 +256,7 @@
                   class:scan-filter-item-active={scanlatorBlacklist.includes(s)}
                   class:scan-filter-item-block={scanlatorBlacklist.includes(s)}
                   role="menuitem"
-                  onclick={() => { onSetScanlatorBlacklist(scanlatorBlacklist.includes(s) ? scanlatorBlacklist.filter(x => x !== s) : [...scanlatorBlacklist, s]); onPageChange(1) }}
+                  onclick={() => { onSetScanlatorBlacklist(scanlatorBlacklist.includes(s) ? scanlatorBlacklist.filter(x => x !== s) : [...scanlatorBlacklist, s]) }}
                 >
                   <span class="scan-filter-check" class:scan-filter-check-block={scanlatorBlacklist.includes(s)}>
                     {#if scanlatorBlacklist.includes(s)}<X size={9} weight="bold" />{/if}

--- a/src/lib/components/series/SeriesDetail.svelte
+++ b/src/lib/components/series/SeriesDetail.svelte
@@ -37,16 +37,13 @@
   interface Props { mangaId: number }
   let { mangaId }: Props = $props()
 
-  let chaptersPerPage: number = $state(25)
   const MANGA_TTL_MS  = 5 * 60 * 1000
-
   const mangaCache: Map<number, { data: Manga; fetchedAt: number }> = new Map()
 
   let manga:           Manga | null = $state(null)
   let loadingManga:    boolean      = $state(false)
   let enqueueing:      Set<number>  = $state(new Set())
   let togglingLibrary: boolean      = $state(false)
-  let chapterPage:     number       = $state(1)
   const viewMode = $derived(settingsState.settings.chapterViewMode ?? 'list')
   let deletingAll:     boolean      = $state(false)
   let refreshing:      boolean      = $state(false)
@@ -84,8 +81,6 @@
   const scanlatorBlacklist = $derived(get('scanlatorBlacklist') as string[])
   const scanlatorForce     = $derived(get('scanlatorForce')     as boolean)
 
-  const totalPages      = $derived(Math.ceil(sortedChapters.length / chaptersPerPage))
-  const pageChapters    = $derived(sortedChapters.slice((chapterPage - 1) * chaptersPerPage, chapterPage * chaptersPerPage))
   const readCount       = $derived(sortedChapters.filter(c => c.read).length)
   const totalCount      = $derived(sortedChapters.length)
   const progressPct     = $derived(totalCount > 0 ? (readCount / totalCount) * 100 : 0)
@@ -543,7 +538,6 @@
       {catsLoading}
       {refreshing}
       onViewModeToggle={() => updateSettings({ chapterViewMode: viewMode === 'list' ? 'grid' : 'list' })}
-      onPageChange={(p) => chapterPage = p}
       onDownloadSelected={downloadSelected}
       onDeleteSelected={deleteSelected}
       onMarkSelectedRead={markSelectedRead}
@@ -563,20 +557,15 @@
     />
 
     <ChapterList
-      {pageChapters}
       {sortedChapters}
       {viewMode}
       {loadingChapters}
       {selectedIds}
       {enqueueing}
-      {chapterPage}
-      {totalPages}
       onOpen={openReaderWithAhead}
       onToggleSelect={toggleSelect}
       onEnqueue={enqueue}
       onDeleteDownload={deleteDownloaded}
-      onPageChange={(p) => chapterPage = p}
-      onPageSizeChange={(n) => { chaptersPerPage = n; chapterPage = Math.min(chapterPage, Math.ceil(sortedChapters.length / n) || 1) }}
       {buildCtxItems}
     />
   </div>


### PR DESCRIPTION
- Replace fixed page-based chapter pagination in SeriesDetail with a scrollable view container
- Style a custom sleek draggable scrollbar with theme token integration in ChapterList.svelte
- Update jump-to-chapter action in SeriesActions.svelte to smoothly scroll target chapters into view
- Remove unused pagination state (chapterPage, chaptersPerPage, totalPages, pageChapters)