### PR TITLE
feat(history): collapse series history, reorder tabs, and add per-ser…

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "prepare": "svelte-kit sync || echo ''",
     "check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
     "check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",
-    "build:static": "MOKU_TARGET=static vite build",
+    "build:static": "npx cross-env MOKU_TARGET=static vite build",
     "build:node": "MOKU_TARGET=node vite build",
     "build:android": "MOKU_TARGET=static vite build",
     "tauri:dev": "tauri dev --config src-tauri/tauri.dev.conf.json",

--- a/src-tauri/tauri.windows.conf.json
+++ b/src-tauri/tauri.windows.conf.json
@@ -1,8 +1,5 @@
 {
   "bundle": {
-    "resources": [
-      "binaries/suwayomi-bundle/bin/Suwayomi-Server.jar",
-      "binaries/suwayomi-bundle/jre/**/*"
-    ]
+    "resources": []
   }
 }

--- a/src/lib/components/browse/Search.svelte
+++ b/src/lib/components/browse/Search.svelte
@@ -109,8 +109,12 @@
   }
 
   async function popular_fanOut(signal: AbortSignal) {
+    if (signal.aborted) return;
     const batch = popular_sourcePool.slice(popular_sourceCursor, popular_sourceCursor + SEARCH_BATCH);
-    if (!batch.length) return;
+    if (!batch.length) {
+      popular_sourceCursor = popular_sourcePool.length;
+      return;
+    }
     await runConcurrent(batch, async (src) => {
       for (let p = 1; p <= SEARCH_PAGES; p++) {
         if (signal.aborted) return;
@@ -216,9 +220,14 @@
   }
 
   $effect(() => {
-    if (!allSources.length) return;
-    if (urlTab === "keyword") popularStart(allSources);
-    else if (urlTab === "tag") startSourceCacheBuild();
+    if ($page.url.pathname !== "/browse") return;
+    const tab = urlTab;
+    const sources = allSources;
+    if (!sources.length) return;
+    untrack(() => {
+      if (tab === "keyword") popularStart(sources);
+      else if (tab === "tag") startSourceCacheBuild();
+    });
   });
 
   onDestroy(() => {

--- a/src/lib/components/downloads/DownloadQueue.svelte
+++ b/src/lib/components/downloads/DownloadQueue.svelte
@@ -1,6 +1,9 @@
 <script lang="ts">
-  import { CircleNotchIcon } from "phosphor-svelte";
+  import { CircleNotchIcon, CaretDown, CaretRight, Trash, ArrowClockwise, X, ArrowLineUp, ArrowLineDown, ArrowsDownUp } from "phosphor-svelte";
+  import Thumbnail    from "$lib/components/shared/manga/Thumbnail.svelte";
   import DownloadItem    from "$lib/components/downloads/DownloadItem.svelte";
+  import ContextMenu, { type MenuEntry } from "$lib/components/shared/ui/ContextMenu.svelte";
+  import { downloadStore } from "$lib/state/downloads.svelte";
   import type { DownloadQueueItem } from "$lib/types/api";
 
   interface Props {
@@ -18,11 +21,112 @@
     queue, loading, isRunning, dequeueing, selected,
     onRemove, onRetry, onSelect,
   }: Props = $props();
+
+  let expandedSeriesIds: Set<number> = $state(new Set());
+  let confirmDeleteSeries: { title: string; items: DownloadQueueItem[] } | null = $state(null);
+  let seriesCtx = $state<{ x: number; y: number; group: SeriesDownloadGroup } | null>(null);
+
+  export interface SeriesDownloadGroup {
+    mangaId:           number;
+    mangaTitle:        string;
+    thumbnailUrl:      string;
+    items:             DownloadQueueItem[];
+    seriesPct:         number;
+    activeChapter:     DownloadQueueItem | null;
+    activeChapterPct:  number;
+    activeChapterName: string;
+    isDownloading:     boolean;
+    hasError:          boolean;
+  }
+
+  const seriesGroups = $derived((() => {
+    const map = new Map<number, DownloadQueueItem[]>();
+    for (const item of queue) {
+      const mId = item.chapter.manga?.id ?? 0;
+      if (!map.has(mId)) map.set(mId, []);
+      map.get(mId)!.push(item);
+    }
+
+    const groups: SeriesDownloadGroup[] = [];
+    for (const [mangaId, items] of map.entries()) {
+      const first = items[0];
+      const title = first.chapter.manga?.title ?? "Unknown Series";
+      const thumb = first.chapter.manga?.thumbnailUrl ?? "";
+
+      const totalProg = items.reduce((sum, i) => sum + (i.progress ?? 0), 0);
+      const seriesPct = Math.round((totalProg / items.length) * 100);
+
+      const downloading = items.find(i => i.state === "DOWNLOADING");
+      const active = downloading ?? items.find(i => (i.progress ?? 0) > 0) ?? items[0];
+      const activePct = active ? Math.round((active.progress ?? 0) * 100) : 0;
+
+      groups.push({
+        mangaId,
+        mangaTitle:        title,
+        thumbnailUrl:      thumb,
+        items,
+        seriesPct,
+        activeChapter:     active,
+        activeChapterPct:  activePct,
+        activeChapterName: active ? active.chapter.name : "",
+        isDownloading:     items.some(i => i.state === "DOWNLOADING"),
+        hasError:          items.some(i => i.state === "ERROR"),
+      });
+    }
+
+    return groups;
+  })());
+
+  function toggleExpand(mangaId: number, e: MouseEvent) {
+    e.stopPropagation();
+    const next = new Set(expandedSeriesIds);
+    if (next.has(mangaId)) next.delete(mangaId);
+    else next.add(mangaId);
+    expandedSeriesIds = next;
+  }
+
+  function retrySeries(items: DownloadQueueItem[], e: MouseEvent) {
+    e.stopPropagation();
+    items.filter(i => i.state === "ERROR").forEach(i => onRetry(i.chapter.id));
+  }
+
+  function openSeriesCtx(e: MouseEvent, group: SeriesDownloadGroup) {
+    e.preventDefault();
+    e.stopPropagation();
+    seriesCtx = { x: e.clientX, y: e.clientY, group };
+  }
+
+  function buildSeriesCtxItems(group: SeriesDownloadGroup): MenuEntry[] {
+    return [
+      {
+        label: "Move series to top",
+        icon: ArrowLineUp,
+        onClick: () => downloadStore.moveSeriesToTop(group.items),
+      },
+      {
+        label: "Move series to bottom",
+        icon: ArrowLineDown,
+        onClick: () => downloadStore.moveSeriesToBottom(group.items),
+      },
+      {
+        label: "Reverse chapter order",
+        icon: ArrowsDownUp,
+        onClick: () => downloadStore.reverseSeriesOrder(group.items),
+      },
+      { separator: true },
+      {
+        label: "Remove series downloads",
+        icon: Trash,
+        danger: true,
+        onClick: () => { confirmDeleteSeries = { title: group.mangaTitle, items: group.items }; },
+      },
+    ];
+  }
 </script>
 
 {#if loading}
   <div class="list">
-    {#each Array(5) as _, i (i)}
+    {#each Array(3) as _, i (i)}
       <div class="sk-row">
         <div class="sk-thumb skeleton"></div>
         <div class="sk-info">
@@ -33,10 +137,6 @@
             <div class="skeleton sk-pages"></div>
           </div>
         </div>
-        <div class="sk-right">
-          <div class="skeleton sk-state"></div>
-          <div class="sk-actions"><div class="skeleton sk-btn"></div></div>
-        </div>
       </div>
     {/each}
   </div>
@@ -44,23 +144,183 @@
   <div class="empty">Queue is empty.</div>
 {:else}
   <div class="list">
-    {#each queue as item, i (item.chapter.id)}
-      <DownloadItem
-        {item}
-        isActive={i === 0 && isRunning}
-        isRemoving={dequeueing.has(item.chapter.id)}
-        isSelected={selected.has(item.chapter.id)}
-        {onRemove}
-        {onRetry}
-        {onSelect}
-      />
+    {#each seriesGroups as group (group.mangaId)}
+      {@const isExpanded = expandedSeriesIds.has(group.mangaId)}
+      <div class="series-card-wrap">
+        <div
+          class="series-card"
+          class:is-downloading={group.isDownloading}
+          oncontextmenu={(e) => openSeriesCtx(e, group)}
+        >
+          <button
+            class="expand-btn"
+            class:expanded={isExpanded}
+            onclick={(e) => toggleExpand(group.mangaId, e)}
+            title={isExpanded ? "Collapse chapters" : "Expand chapters"}
+          >
+            {#if isExpanded}
+              <CaretDown size={12} weight="bold" />
+            {:else}
+              <CaretRight size={12} weight="bold" />
+            {/if}
+          </button>
+
+          {#if group.thumbnailUrl}
+            <div class="thumb">
+              <Thumbnail src={group.thumbnailUrl} alt={group.mangaTitle} class="thumb-img" />
+            </div>
+          {/if}
+
+          <div class="series-info">
+            <div class="series-title-row">
+              <span class="series-title">{group.mangaTitle}</span>
+              <span class="series-count-badge">{group.items.length} {group.items.length === 1 ? "chapter" : "chapters"}</span>
+            </div>
+
+            {#if group.activeChapter}
+              <div class="series-prog-container">
+                <div class="prog-item">
+                  <span class="prog-label" title="Current chapter: {group.activeChapterName}">
+                    Current ({group.activeChapterName}):
+                  </span>
+                  <div class="prog-track">
+                    <div class="prog-fill" style="width: {group.activeChapterPct}%"></div>
+                  </div>
+                  <span class="prog-pct">{group.activeChapterPct}%</span>
+                </div>
+              </div>
+            {/if}
+          </div>
+
+          <div class="series-actions">
+            {#if group.hasError}
+              <button class="action-btn retry" onclick={(e) => retrySeries(group.items, e)} title="Retry errors">
+                <ArrowClockwise size={12} weight="bold" />
+              </button>
+            {/if}
+            <button
+              class="action-btn remove"
+              onclick={(e) => { e.stopPropagation(); confirmDeleteSeries = { title: group.mangaTitle, items: group.items }; }}
+              title="Remove series downloads"
+            >
+              <Trash size={13} weight="light" />
+            </button>
+          </div>
+        </div>
+
+        {#if isExpanded}
+          <div class="sub-item-list">
+            {#each group.items as item (item.chapter.id)}
+              {@const globalIdx = queue.findIndex(q => q.chapter.id === item.chapter.id)}
+              <DownloadItem
+                {item}
+                isActive={globalIdx === 0 && isRunning}
+                isRemoving={dequeueing.has(item.chapter.id)}
+                isSelected={selected.has(item.chapter.id)}
+                {onRemove}
+                {onRetry}
+                {onSelect}
+              />
+            {/each}
+          </div>
+        {/if}
+      </div>
     {/each}
   </div>
 {/if}
 
+{#if confirmDeleteSeries}
+  <div
+    class="modal-backdrop"
+    role="presentation"
+    onclick={() => confirmDeleteSeries = null}
+    onkeydown={(e) => e.key === 'Escape' && (confirmDeleteSeries = null)}
+  >
+    <div class="modal-card" role="dialog" aria-modal="true" onclick={(e) => e.stopPropagation()}>
+      <div class="modal-header">
+        <span class="modal-title">Remove downloads?</span>
+      </div>
+      <div class="modal-body">
+        <p class="modal-msg">Remove all chapter downloads for <strong>{confirmDeleteSeries.title}</strong> from the queue?</p>
+      </div>
+      <div class="modal-actions">
+        <button class="btn-cancel" onclick={() => confirmDeleteSeries = null}>Cancel</button>
+        <button
+          class="btn-danger"
+          onclick={() => {
+            if (confirmDeleteSeries) {
+              confirmDeleteSeries.items.forEach(i => onRemove(i.chapter.id));
+            }
+            confirmDeleteSeries = null;
+          }}
+        >
+          Remove
+        </button>
+      </div>
+    </div>
+  </div>
+{/if}
+
+{#if seriesCtx}
+  <ContextMenu
+    x={seriesCtx.x}
+    y={seriesCtx.y}
+    items={buildSeriesCtxItems(seriesCtx.group)}
+    onClose={() => seriesCtx = null}
+  />
+{/if}
+
 <style>
-  .list  { display: flex; flex-direction: column; gap: var(--sp-2); }
+  .list  { display: flex; flex-direction: column; gap: var(--sp-3); }
   .empty { display: flex; align-items: center; justify-content: center; height: 160px; color: var(--text-faint); font-family: var(--font-ui); font-size: var(--text-xs); letter-spacing: var(--tracking-wide); }
+
+  .series-card-wrap { display: flex; flex-direction: column; gap: 2px; }
+
+  .series-card {
+    display: flex; align-items: center; gap: var(--sp-3); padding: var(--sp-3);
+    background: var(--bg-raised); border: 1px solid var(--border-dim); border-radius: var(--radius-md);
+    transition: border-color var(--t-fast), background var(--t-fast);
+  }
+  .series-card:hover { border-color: var(--border-strong); background: var(--bg-elevated); }
+  .series-card.is-downloading { border-color: var(--accent-dim); background: color-mix(in srgb, var(--accent) 5%, var(--bg-raised)); }
+
+  .expand-btn {
+    display: flex; align-items: center; justify-content: center;
+    width: 22px; height: 22px; border-radius: var(--radius-sm);
+    border: none; background: none; color: var(--text-faint);
+    cursor: pointer; flex-shrink: 0;
+    transition: color var(--t-fast), background var(--t-fast);
+  }
+  .expand-btn:hover { color: var(--text-primary); background: var(--bg-overlay); }
+  .expand-btn.expanded { color: var(--accent-fg); }
+
+  .thumb { width: 36px; height: 54px; border-radius: var(--radius-sm); overflow: hidden; background: var(--bg-overlay); flex-shrink: 0; border: 1px solid var(--border-dim); }
+  :global(.thumb-img) { width: 100%; height: 100%; object-fit: cover; }
+
+  .series-info { flex: 1; display: flex; flex-direction: column; gap: 4px; min-width: 0; }
+  .series-title-row { display: flex; align-items: center; gap: var(--sp-2); min-width: 0; }
+  .series-title { font-size: var(--text-sm); font-weight: var(--weight-medium); color: var(--text-primary); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+  .series-count-badge { font-family: var(--font-ui); font-size: var(--text-2xs); color: var(--text-faint); opacity: 0.7; flex-shrink: 0; white-space: nowrap; }
+
+  .series-prog-container { display: flex; flex-direction: column; gap: 3px; margin-top: 2px; }
+  .prog-item { display: flex; align-items: center; gap: var(--sp-2); }
+  .prog-label { font-family: var(--font-ui); font-size: 10px; color: var(--text-muted); min-width: 85px; max-width: 160px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; flex-shrink: 0; }
+  .prog-track { flex: 1; height: 3px; background: var(--border-base); border-radius: var(--radius-full); overflow: hidden; }
+  .prog-fill { height: 100%; background: var(--accent); border-radius: var(--radius-full); transition: width 0.3s ease; }
+  .prog-fill.series-fill { background: color-mix(in srgb, var(--accent) 70%, #3b82f6); }
+  .prog-pct { font-family: var(--font-ui); font-size: 10px; font-weight: 600; color: var(--accent-fg); min-width: 28px; text-align: right; flex-shrink: 0; }
+
+  .series-actions { display: flex; align-items: center; gap: 4px; flex-shrink: 0; }
+  .action-btn { display: flex; align-items: center; justify-content: center; width: 24px; height: 24px; border-radius: var(--radius-sm); color: var(--text-faint); background: none; border: none; cursor: pointer; padding: 0; transition: color var(--t-base), background var(--t-base); }
+  .action-btn:hover { color: var(--text-primary); background: var(--bg-overlay); }
+  .action-btn.remove:hover { color: var(--color-error); background: var(--color-error-bg); }
+  .action-btn.retry:hover  { color: var(--accent-fg); background: var(--accent-muted); }
+
+  .sub-item-list {
+    margin-left: 28px; margin-top: 2px;
+    padding-left: var(--sp-3); border-left: 2px solid var(--border-dim);
+    display: flex; flex-direction: column; gap: var(--sp-2);
+  }
 
   @keyframes shimmer { from { background-position: -200% 0 } to { background-position: 200% 0 } }
   .skeleton {
@@ -81,10 +341,41 @@
   .sk-title        { height: 12px; width: clamp(120px, 55%, 280px); }
   .sk-chapter      { height: 10px; width: clamp(80px, 35%, 200px); }
   .sk-progress-row { display: flex; align-items: center; gap: var(--sp-2); }
-  .sk-bar          { flex: 1; height: 2px; }
-  .sk-pages        { width: 28px; height: 9px; }
-  .sk-right        { display: flex; flex-direction: column; align-items: flex-end; gap: var(--sp-1); flex-shrink: 0; }
-  .sk-state        { width: 54px; height: 9px; }
-  .sk-actions      { display: flex; gap: 2px; }
-  .sk-btn          { width: 20px; height: 20px; border-radius: var(--radius-sm); }
+
+  .modal-backdrop {
+    position: fixed; inset: 0; z-index: 1000;
+    background: rgba(0, 0, 0, 0.5);
+    display: flex; align-items: center; justify-content: center;
+    animation: fadeIn 0.12s ease both;
+  }
+  .modal-card {
+    background: var(--bg-surface); border: 1px solid var(--border-base);
+    border-radius: var(--radius-lg); width: 340px; max-width: 90vw;
+    box-shadow: 0 8px 32px rgba(0, 0, 0, 0.5); overflow: hidden;
+    display: flex; flex-direction: column;
+  }
+  .modal-header { padding: var(--sp-4) var(--sp-4) var(--sp-2); }
+  .modal-title  { font-size: var(--text-sm); font-weight: var(--weight-medium); color: var(--text-primary); }
+  .modal-body   { padding: 0 var(--sp-4) var(--sp-4); }
+  .modal-msg    { font-family: var(--font-ui); font-size: var(--text-xs); color: var(--text-muted); line-height: 1.4; margin: 0; }
+  .modal-actions {
+    display: flex; align-items: center; justify-content: flex-end; gap: var(--sp-2);
+    padding: var(--sp-3) var(--sp-4); border-top: 1px solid var(--border-dim); background: var(--bg-raised);
+  }
+  .btn-cancel, .btn-danger {
+    font-family: var(--font-ui); font-size: var(--text-xs); letter-spacing: var(--tracking-wide);
+    padding: 5px 12px; border-radius: var(--radius-sm); cursor: pointer;
+    transition: background var(--t-base), color var(--t-base), border-color var(--t-base);
+  }
+  .btn-cancel { border: 1px solid var(--border-dim); background: none; color: var(--text-muted); }
+  .btn-cancel:hover { color: var(--text-primary); border-color: var(--border-strong); }
+  .btn-danger {
+    border: 1px solid color-mix(in srgb, var(--color-error) 40%, transparent);
+    background: var(--color-error-bg); color: var(--color-error);
+  }
+  .btn-danger:hover {
+    background: color-mix(in srgb, var(--color-error) 20%, transparent);
+    border-color: var(--color-error);
+  }
+  @keyframes fadeIn { from { opacity: 0 } to { opacity: 1 } }
 </style>

--- a/src/lib/components/downloads/DownloadQueue.svelte
+++ b/src/lib/components/downloads/DownloadQueue.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { CircleNotchIcon, CaretDown, CaretRight, Trash, ArrowClockwise, X, ArrowLineUp, ArrowLineDown, ArrowsDownUp } from "phosphor-svelte";
+  import { CircleNotchIcon, CaretUp, CaretDown, CaretRight, Trash, ArrowClockwise, X, ArrowLineUp, ArrowLineDown, ArrowsDownUp } from "phosphor-svelte";
   import Thumbnail    from "$lib/components/shared/manga/Thumbnail.svelte";
   import DownloadItem    from "$lib/components/downloads/DownloadItem.svelte";
   import ContextMenu, { type MenuEntry } from "$lib/components/shared/ui/ContextMenu.svelte";
@@ -98,6 +98,17 @@
 
   function buildSeriesCtxItems(group: SeriesDownloadGroup): MenuEntry[] {
     return [
+      {
+        label: "Move up",
+        icon: CaretUp,
+        onClick: () => downloadStore.moveSeries(group.items, "up"),
+      },
+      {
+        label: "Move down",
+        icon: CaretDown,
+        onClick: () => downloadStore.moveSeries(group.items, "down"),
+      },
+      { separator: true },
       {
         label: "Move series to top",
         icon: ArrowLineUp,

--- a/src/lib/components/recent/HistoryTab.svelte
+++ b/src/lib/components/recent/HistoryTab.svelte
@@ -1,8 +1,8 @@
 <script lang="ts">
-  import { Books, ClockCounterClockwise, Clock, BookOpen, Fire, TrendUp } from 'phosphor-svelte'
+  import { Books, ClockCounterClockwise, Clock, BookOpen, Fire, TrendUp, Trash, CaretDown, CaretRight } from 'phosphor-svelte'
   import Thumbnail from '$lib/components/shared/manga/Thumbnail.svelte'
   import { timeAgo, formatReadTime } from '$lib/core/util'
-  import type { HistoryGroup, ReadSession } from './lib/recentHistory'
+  import type { HistoryGroup, MangaHistoryEntry } from './lib/recentHistory'
 
   interface Stats {
     currentStreakDays:  number
@@ -12,15 +12,27 @@
   }
 
   interface Props {
-    groups:        HistoryGroup[]
-    hasHistory:    boolean
-    historySearch: string
-    stats:         Stats
-    thumbFor:      (mangaId: number, fallback: string) => string
-    onOpenSeries:  (session: ReadSession) => void
+    groups:               HistoryGroup[]
+    hasHistory:           boolean
+    historySearch:        string
+    stats:                Stats
+    thumbFor:             (mangaId: number, fallback: string) => string
+    onOpenChapter:        (mangaId: number, chapterId: number) => void
+    onDeleteMangaHistory: (mangaId: number) => void
   }
 
-  let { groups, hasHistory, historySearch, stats, thumbFor, onOpenSeries }: Props = $props()
+  let { groups, hasHistory, historySearch, stats, thumbFor, onOpenChapter, onDeleteMangaHistory }: Props = $props()
+
+  let confirmDelete: { id: number; title: string } | null = $state(null)
+  let expandedMangaIds: Set<number> = $state(new Set())
+
+  function toggleExpand(mangaId: number, e: MouseEvent) {
+    e.stopPropagation()
+    const next = new Set(expandedMangaIds)
+    if (next.has(mangaId)) next.delete(mangaId)
+    else next.add(mangaId)
+    expandedMangaIds = next
+  }
 
   function formatDuration(ms: number): string {
     const totalMin = Math.round(ms / 60_000)
@@ -88,36 +100,87 @@
             <div class="day-rule"></div>
           </div>
           <div class="session-list">
-            {#each items as session (session.id)}
-              <button class="session-row" onclick={() => onOpenSeries(session)}>
-                <div class="thumb-wrap">
-                  <Thumbnail
-                    src={thumbFor(session.mangaId, session.thumbnailUrl)}
-                    alt={session.mangaTitle}
-                    class="thumb"
-                  />
-                  {#if session.chaptersSpanned > 1}
-                    <span class="session-count">{session.chaptersSpanned}</span>
-                  {/if}
-                </div>
-                <div class="session-info">
-                  <span class="session-title">{session.mangaTitle}</span>
-                  <span class="session-chapter">
-                    {#if session.chaptersSpanned > 1}
-                      {session.startChapterName}<span class="ch-arrow">→</span>{session.endChapterName}
+            {#each items as item (item.mangaId)}
+              {@const isExpanded = expandedMangaIds.has(item.mangaId)}
+              <div class="manga-card-wrap">
+                <div
+                  class="session-row"
+                  role="button"
+                  tabindex="0"
+                  onclick={() => onOpenChapter(item.mangaId, item.latestChapterId)}
+                  onkeydown={(e) => e.key === 'Enter' && onOpenChapter(item.mangaId, item.latestChapterId)}
+                >
+                  <button
+                    class="expand-btn"
+                    class:expanded={isExpanded}
+                    onclick={(e) => toggleExpand(item.mangaId, e)}
+                    title={isExpanded ? 'Collapse chapters' : 'Expand chapters'}
+                  >
+                    {#if isExpanded}
+                      <CaretDown size={12} weight="bold" />
                     {:else}
-                      {session.endChapterName}
-                      {#if session.endPage > 1}
-                        <span class="ch-page">· p.{session.endPage}</span>
+                      <CaretRight size={12} weight="bold" />
+                    {/if}
+                  </button>
+                  <div class="thumb-wrap">
+                    <Thumbnail
+                      src={thumbFor(item.mangaId, item.thumbnailUrl)}
+                      alt={item.mangaTitle}
+                      class="thumb"
+                    />
+                    {#if item.chaptersSpanned > 1}
+                      <span class="session-count">{item.chaptersSpanned}</span>
+                    {/if}
+                  </div>
+                  <div class="session-info">
+                    <span class="session-title">{item.mangaTitle}</span>
+                    <span class="session-chapter">
+                      {item.latestChapterName}
+                      {#if item.chaptersSpanned > 1}
+                        <span class="ch-page">· {item.chaptersSpanned} chapters read</span>
                       {/if}
-                    {/if}
-                    {#if session.durationMs >= 60_000}
-                      <span class="ch-duration">· {formatDuration(session.durationMs)}</span>
-                    {/if}
-                  </span>
+                      {#if item.durationMs >= 60_000}
+                        <span class="ch-duration">· {formatDuration(item.durationMs)}</span>
+                      {/if}
+                    </span>
+                  </div>
+                  <span class="session-time">{timeAgo(item.endedAt)}</span>
+                  <button
+                    class="delete-btn"
+                    onclick={(e) => { e.stopPropagation(); confirmDelete = { id: item.mangaId, title: item.mangaTitle } }}
+                    title="Clear history for this series"
+                  >
+                    <Trash size={13} weight="light" />
+                  </button>
                 </div>
-                <span class="session-time">{timeAgo(session.endedAt)}</span>
-              </button>
+
+                {#if isExpanded}
+                  <div class="sub-chapter-list">
+                    {#each item.chapters as ch (ch.chapterId)}
+                      <div
+                        class="sub-chapter-row"
+                        role="button"
+                        tabindex="0"
+                        onclick={(e) => { e.stopPropagation(); onOpenChapter(item.mangaId, ch.chapterId) }}
+                        onkeydown={(e) => e.key === 'Enter' && (e.stopPropagation(), onOpenChapter(item.mangaId, ch.chapterId))}
+                      >
+                        <div class="sub-chapter-info">
+                          <span class="sub-chapter-name">
+                            {ch.chapterName}
+                            {#if ch.endPage > 1}
+                              <span class="ch-page">· p.{ch.endPage}</span>
+                            {/if}
+                          </span>
+                          {#if ch.durationMs >= 60_000}
+                            <span class="sub-chapter-meta">{formatDuration(ch.durationMs)}</span>
+                          {/if}
+                        </div>
+                        <span class="sub-chapter-time">{timeAgo(ch.endedAt)}</span>
+                      </div>
+                    {/each}
+                  </div>
+                {/if}
+              </div>
             {/each}
           </div>
         </div>
@@ -125,6 +188,36 @@
     </div>
   {/if}
 </div>
+
+{#if confirmDelete}
+  <div
+    class="modal-backdrop"
+    role="presentation"
+    onclick={() => confirmDelete = null}
+    onkeydown={(e) => e.key === 'Escape' && (confirmDelete = null)}
+  >
+    <div class="modal-card" role="dialog" aria-modal="true" onclick={(e) => e.stopPropagation()}>
+      <div class="modal-header">
+        <span class="modal-title">Clear history?</span>
+      </div>
+      <div class="modal-body">
+        <p class="modal-msg">Remove all reading history for <strong>{confirmDelete.title}</strong>?</p>
+      </div>
+      <div class="modal-actions">
+        <button class="btn-cancel" onclick={() => confirmDelete = null}>Cancel</button>
+        <button
+          class="btn-danger"
+          onclick={() => {
+            if (confirmDelete) onDeleteMangaHistory(confirmDelete.id)
+            confirmDelete = null
+          }}
+        >
+          Clear
+        </button>
+      </div>
+    </div>
+  </div>
+{/if}
 
 <style>
   .root { display: flex; flex-direction: column; height: 100%; overflow: hidden; }
@@ -162,7 +255,10 @@
   .day-rule   { flex: 1; height: 1px; background: var(--border-dim); }
   .session-list { display: flex; flex-direction: column; gap: var(--sp-2); }
 
+  .manga-card-wrap { display: flex; flex-direction: column; gap: 2px; }
+
   .session-row {
+    position: relative;
     display: flex; align-items: center; gap: var(--sp-3);
     width: 100%; padding: var(--sp-3); border-radius: var(--radius-md);
     border: 1px solid var(--border-dim); background: var(--bg-raised);
@@ -170,6 +266,17 @@
     transition: border-color var(--t-fast), background var(--t-fast);
   }
   .session-row:hover { border-color: var(--border-strong); background: var(--bg-elevated); }
+  .session-row:hover .delete-btn { opacity: 1; }
+
+  .expand-btn {
+    display: flex; align-items: center; justify-content: center;
+    width: 22px; height: 22px; border-radius: var(--radius-sm);
+    border: none; background: none; color: var(--text-faint);
+    cursor: pointer; flex-shrink: 0;
+    transition: color var(--t-fast), background var(--t-fast);
+  }
+  .expand-btn:hover { color: var(--text-primary); background: var(--bg-overlay); }
+  .expand-btn.expanded { color: var(--accent-fg); }
 
   .thumb-wrap { position: relative; flex-shrink: 0; }
   :global(.thumb) { width: 38px; height: 54px; object-fit: cover; display: block; border-radius: var(--radius-sm); border: 1px solid var(--border-dim); }
@@ -188,13 +295,48 @@
     font-family: var(--font-ui); font-size: var(--text-xs); color: var(--text-muted);
     letter-spacing: var(--tracking-wide); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; min-width: 0;
   }
-  .ch-arrow    { color: var(--text-faint); opacity: 0.35; flex-shrink: 0; }
   .ch-page     { color: var(--text-faint); opacity: 0.5;  flex-shrink: 0; }
   .ch-duration { color: var(--text-faint); opacity: 0.5;  flex-shrink: 0; }
   .session-time {
     font-family: var(--font-ui); font-size: var(--text-2xs); color: var(--text-faint);
     letter-spacing: var(--tracking-wide); flex-shrink: 0; white-space: nowrap; opacity: 0.45;
   }
+
+  .delete-btn {
+    display: flex; align-items: center; justify-content: center;
+    width: 26px; height: 26px; border-radius: var(--radius-sm);
+    border: none; background: none; color: var(--text-faint);
+    cursor: pointer; opacity: 0; flex-shrink: 0;
+    transition: opacity var(--t-fast), color var(--t-fast), background var(--t-fast);
+  }
+  .delete-btn:hover {
+    color: var(--color-error);
+    background: var(--color-error-bg);
+  }
+
+  .sub-chapter-list {
+    margin-left: 28px; margin-top: 2px;
+    padding-left: var(--sp-3); border-left: 2px solid var(--border-dim);
+    display: flex; flex-direction: column; gap: 2px;
+  }
+
+  .sub-chapter-row {
+    display: flex; align-items: center; gap: var(--sp-3);
+    padding: var(--sp-2) var(--sp-3); border-radius: var(--radius-sm);
+    background: var(--bg-surface); border: 1px solid var(--border-dim);
+    cursor: pointer; text-align: left;
+    transition: background var(--t-fast), border-color var(--t-fast);
+  }
+  .sub-chapter-row:hover { background: var(--bg-raised); border-color: var(--border-strong); }
+
+  .sub-chapter-info { flex: 1; display: flex; align-items: center; gap: var(--sp-2); min-width: 0; overflow: hidden; }
+  .sub-chapter-name {
+    font-family: var(--font-ui); font-size: var(--text-xs);
+    font-weight: var(--weight-medium); color: var(--text-secondary);
+    white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+  }
+  .sub-chapter-meta { font-family: var(--font-ui); font-size: var(--text-2xs); color: var(--text-faint); opacity: 0.5; flex-shrink: 0; }
+  .sub-chapter-time { font-family: var(--font-ui); font-size: var(--text-2xs); color: var(--text-faint); opacity: 0.45; flex-shrink: 0; }
 
   .empty { flex: 1; display: flex; flex-direction: column; align-items: center; justify-content: center; gap: var(--sp-2); }
   .empty-icon-wrap {
@@ -205,4 +347,41 @@
   }
   .empty-text { font-size: var(--text-sm); font-weight: var(--weight-medium); color: var(--text-muted); }
   .empty-hint { font-size: var(--text-xs); color: var(--text-faint); }
+
+  .modal-backdrop {
+    position: fixed; inset: 0; z-index: var(--z-settings, 1000);
+    background: rgba(0, 0, 0, 0.5);
+    display: flex; align-items: center; justify-content: center;
+    animation: fadeIn 0.12s ease both;
+  }
+  .modal-card {
+    background: var(--bg-surface); border: 1px solid var(--border-base);
+    border-radius: var(--radius-lg); width: 340px; max-width: 90vw;
+    box-shadow: 0 8px 32px rgba(0, 0, 0, 0.5); overflow: hidden;
+    display: flex; flex-direction: column;
+  }
+  .modal-header { padding: var(--sp-4) var(--sp-4) var(--sp-2); }
+  .modal-title  { font-size: var(--text-sm); font-weight: var(--weight-medium); color: var(--text-primary); }
+  .modal-body   { padding: 0 var(--sp-4) var(--sp-4); }
+  .modal-msg    { font-family: var(--font-ui); font-size: var(--text-xs); color: var(--text-muted); line-height: 1.4; margin: 0; }
+  .modal-actions {
+    display: flex; align-items: center; justify-content: flex-end; gap: var(--sp-2);
+    padding: var(--sp-3) var(--sp-4); border-top: 1px solid var(--border-dim); background: var(--bg-raised);
+  }
+  .btn-cancel, .btn-danger {
+    font-family: var(--font-ui); font-size: var(--text-xs); letter-spacing: var(--tracking-wide);
+    padding: 5px 12px; border-radius: var(--radius-sm); cursor: pointer;
+    transition: background var(--t-base), color var(--t-base), border-color var(--t-base);
+  }
+  .btn-cancel { border: 1px solid var(--border-dim); background: none; color: var(--text-muted); }
+  .btn-cancel:hover { color: var(--text-primary); border-color: var(--border-strong); }
+  .btn-danger {
+    border: 1px solid color-mix(in srgb, var(--color-error) 40%, transparent);
+    background: var(--color-error-bg); color: var(--color-error);
+  }
+  .btn-danger:hover {
+    background: color-mix(in srgb, var(--color-error) 20%, transparent);
+    border-color: var(--color-error);
+  }
+  @keyframes fadeIn { from { opacity: 0 } to { opacity: 1 } }
 </style>

--- a/src/lib/components/recent/Recent.svelte
+++ b/src/lib/components/recent/Recent.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { onMount, onDestroy } from 'svelte'
+  import { goto }               from '$app/navigation'
   import { getAdapter }         from '$lib/request-manager'
   import { cache, CACHE_KEYS, CACHE_GROUPS } from '$lib/core/cache/queryCache'
   import { homeState, clearHistory } from '$lib/state/home.svelte'
@@ -7,7 +8,7 @@
   import { setActiveManga, openReaderForChapter, setPreviewManga } from '$lib/state/series.svelte'
   import { addToast }           from '$lib/state/notifications.svelte'
   import { downloadStore }      from '$lib/state/downloads.svelte'
-  import { groupByDay }                                from './lib/recentHistory'
+  import { collapseAndGroupByDay }                     from './lib/recentHistory'
   import { fetchedAtMs, parseServerTimestamp, groupUpdatesByDay } from './lib/recentUpdates'
   import RecentToolbar  from './RecentToolbar.svelte'
   import UpdatesTab     from './UpdatesTab.svelte'
@@ -19,7 +20,7 @@
   const RECENT_UPDATES_TTL_MS = 60 * 1_000
   const UPDATE_STATUS_POLL_MS = 2_000
 
-  let tab:                 'updates' | 'history' = $state('updates')
+  let tab:                 'updates' | 'history' = $state('history')
   let historySearch:       string  = $state('')
   let updatesSearch:       string  = $state('')
   let historyConfirmClear: boolean = $state(false)
@@ -77,7 +78,7 @@
       )
     : historyState.sessions)
 
-  const historyGroups = $derived(groupByDay(filteredHistory))
+  const historyGroups = $derived(collapseAndGroupByDay(filteredHistory))
 
   function applyUpdateStatus(statusRes: { isRunning?: boolean; finishedJobs?: number; totalJobs?: number; lastUpdated?: unknown } | null) {
     if (!statusRes) return
@@ -276,11 +277,8 @@
         {historySearch}
         stats={historyState.stats}
         {thumbFor}
-        onOpenSeries={(session) => setPreviewManga({
-          id:           session.mangaId,
-          title:        session.mangaTitle,
-          thumbnailUrl: thumbFor(session.mangaId, session.thumbnailUrl),
-        } as any)}
+        onOpenChapter={(mangaId, chapterId) => goto(`/reader/${mangaId}/${chapterId}`)}
+        onDeleteMangaHistory={(mangaId) => historyState.clearMangaHistory(mangaId)}
       />
     {/if}
   </div>

--- a/src/lib/components/recent/RecentToolbar.svelte
+++ b/src/lib/components/recent/RecentToolbar.svelte
@@ -32,13 +32,13 @@
   <span class="heading">Recent</span>
 
   <div class="tabs">
-    <button class="tab" class:active={tab === 'updates'} onclick={() => onTabChange('updates')}>
-      <NewspaperClipping size={11} weight="bold" />
-      Updates
-    </button>
     <button class="tab" class:active={tab === 'history'} onclick={() => onTabChange('history')}>
       <BookOpen size={11} weight="bold" />
       History
+    </button>
+    <button class="tab" class:active={tab === 'updates'} onclick={() => onTabChange('updates')}>
+      <NewspaperClipping size={11} weight="bold" />
+      Updates
     </button>
   </div>
 

--- a/src/lib/components/recent/lib/recentHistory.ts
+++ b/src/lib/components/recent/lib/recentHistory.ts
@@ -3,17 +3,96 @@ import type { ReadSession } from '$lib/types/history'
 
 export type { ReadSession }
 
-export interface HistoryGroup {
-  label: string
-  items: ReadSession[]
+export interface ChapterHistoryEntry {
+  chapterId:   number
+  chapterName: string
+  endPage:     number
+  durationMs:  number
+  endedAt:     number
+  readCount:   number
 }
 
-export function groupByDay(sessions: ReadSession[]): HistoryGroup[] {
-  const map = new Map<string, ReadSession[]>()
+export interface MangaHistoryEntry {
+  mangaId:           number
+  mangaTitle:        string
+  thumbnailUrl:      string
+  latestChapterId:   number
+  latestChapterName: string
+  chaptersSpanned:   number
+  durationMs:        number
+  endedAt:           number
+  chapters:          ChapterHistoryEntry[]
+}
+
+export interface HistoryGroup {
+  label: string
+  items: MangaHistoryEntry[]
+}
+
+export function collapseAndGroupByDay(sessions: ReadSession[]): HistoryGroup[] {
+  const mangaMap = new Map<number, ReadSession[]>()
   for (const s of sessions) {
-    const label = dayLabel(s.endedAt)
-    if (!map.has(label)) map.set(label, [])
-    map.get(label)!.push(s)
+    if (!mangaMap.has(s.mangaId)) mangaMap.set(s.mangaId, [])
+    mangaMap.get(s.mangaId)!.push(s)
   }
-  return Array.from(map.entries()).map(([label, items]) => ({ label, items }))
+
+  const entries: MangaHistoryEntry[] = []
+  for (const [mangaId, mSessions] of mangaMap.entries()) {
+    const latest = mSessions[0]
+    let totalDurationMs = 0
+    const uniqueChapters = new Set<number>()
+    const chapterMap = new Map<number, ReadSession[]>()
+
+    for (const s of mSessions) {
+      totalDurationMs += s.durationMs
+      uniqueChapters.add(s.endChapterId)
+      if (s.chaptersSpanned > 1) uniqueChapters.add(s.startChapterId)
+
+      if (!chapterMap.has(s.endChapterId)) chapterMap.set(s.endChapterId, [])
+      chapterMap.get(s.endChapterId)!.push(s)
+    }
+
+    const chapters: ChapterHistoryEntry[] = []
+    for (const [chapterId, cSessions] of chapterMap.entries()) {
+      const latestCS = cSessions[0]
+      let cDur = 0
+      let maxPage = 0
+      for (const cs of cSessions) {
+        cDur += cs.durationMs
+        maxPage = Math.max(maxPage, cs.endPage)
+      }
+      chapters.push({
+        chapterId,
+        chapterName: latestCS.endChapterName,
+        endPage:     maxPage,
+        durationMs:  cDur,
+        endedAt:     latestCS.endedAt,
+        readCount:   cSessions.length,
+      })
+    }
+    chapters.sort((a, b) => b.endedAt - a.endedAt)
+
+    entries.push({
+      mangaId,
+      mangaTitle:        latest.mangaTitle,
+      thumbnailUrl:      latest.thumbnailUrl,
+      latestChapterId:   latest.endChapterId,
+      latestChapterName: latest.endChapterName,
+      chaptersSpanned:   uniqueChapters.size,
+      durationMs:        totalDurationMs,
+      endedAt:           latest.endedAt,
+      chapters,
+    })
+  }
+
+  entries.sort((a, b) => b.endedAt - a.endedAt)
+
+  const groupMap = new Map<string, MangaHistoryEntry[]>()
+  for (const entry of entries) {
+    const label = dayLabel(entry.endedAt)
+    if (!groupMap.has(label)) groupMap.set(label, [])
+    groupMap.get(label)!.push(entry)
+  }
+
+  return Array.from(groupMap.entries()).map(([label, items]) => ({ label, items }))
 }

--- a/src/lib/state/downloads.svelte.ts
+++ b/src/lib/state/downloads.svelte.ts
@@ -320,6 +320,50 @@ class DownloadStore {
     finally { this.batchWorking = false; }
   }
 
+  async moveSeries(items: DownloadQueueItem[], direction: "up" | "down") {
+    if (this.batchWorking || !items.length) return;
+    const targetMangaId = items[0]?.chapter.manga?.id ?? 0;
+    const groupOrder: number[] = [];
+    for (const item of this.queue) {
+      const mId = item.chapter.manga?.id ?? 0;
+      if (!groupOrder.includes(mId)) groupOrder.push(mId);
+    }
+    const gIdx = groupOrder.indexOf(targetMangaId);
+    if (gIdx === -1) return;
+    const targetIdx = direction === "up" ? gIdx - 1 : gIdx + 1;
+    if (targetIdx < 0 || targetIdx >= groupOrder.length) return;
+
+    this.batchWorking = true;
+    [groupOrder[gIdx], groupOrder[targetIdx]] = [groupOrder[targetIdx], groupOrder[gIdx]];
+
+    const map = new Map<number, DownloadQueueItem[]>();
+    for (const item of this.queue) {
+      const mId = item.chapter.manga?.id ?? 0;
+      if (!map.has(mId)) map.set(mId, []);
+      map.get(mId)!.push(item);
+    }
+
+    const first = this.isRunning ? 1 : 0;
+    const active = this.queue.slice(0, first);
+    const reorderedMoveable: DownloadQueueItem[] = [];
+    for (const mId of groupOrder) {
+      const groupItems = map.get(mId) ?? [];
+      for (const item of groupItems) {
+        if (first === 1 && item.chapter.id === active[0]?.chapter.id) continue;
+        reorderedMoveable.push(item);
+      }
+    }
+    const newQueue = [...active, ...reorderedMoveable];
+    if (this.status) this.status = { ...this.status, queue: newQueue };
+    try {
+      for (let i = 0; i < reorderedMoveable.length; i++) {
+        await reorderDownload(reorderedMoveable[i].chapter.id, first + i);
+      }
+      await this.poll();
+    } catch { await this.poll(); }
+    finally { this.batchWorking = false; }
+  }
+
   async moveSeriesToTop(items: DownloadQueueItem[]) {
     if (this.batchWorking || !items.length) return;
     this.batchWorking = true;

--- a/src/lib/state/downloads.svelte.ts
+++ b/src/lib/state/downloads.svelte.ts
@@ -320,6 +320,71 @@ class DownloadStore {
     finally { this.batchWorking = false; }
   }
 
+  async moveSeriesToTop(items: DownloadQueueItem[]) {
+    if (this.batchWorking || !items.length) return;
+    this.batchWorking = true;
+    const seriesIdSet = new Set(items.map(i => i.chapter.id));
+    const first  = this.isRunning ? 1 : 0;
+    const active = this.queue.slice(0, first);
+    const moveable = this.queue.slice(first);
+    const seriesItems = moveable.filter(i => seriesIdSet.has(i.chapter.id));
+    const rest        = moveable.filter(i => !seriesIdSet.has(i.chapter.id));
+    const newQueue    = [...active, ...seriesItems, ...rest];
+    if (this.status) this.status = { ...this.status, queue: newQueue };
+    try {
+      for (let i = 0; i < seriesItems.length; i++) {
+        await reorderDownload(seriesItems[i].chapter.id, first + i);
+      }
+      await this.poll();
+    } catch { await this.poll(); }
+    finally { this.batchWorking = false; }
+  }
+
+  async moveSeriesToBottom(items: DownloadQueueItem[]) {
+    if (this.batchWorking || !items.length) return;
+    this.batchWorking = true;
+    const seriesIdSet = new Set(items.map(i => i.chapter.id));
+    const first  = this.isRunning ? 1 : 0;
+    const active = this.queue.slice(0, first);
+    const moveable = this.queue.slice(first);
+    const seriesItems = moveable.filter(i => seriesIdSet.has(i.chapter.id));
+    const rest        = moveable.filter(i => !seriesIdSet.has(i.chapter.id));
+    const newQueue    = [...active, ...rest, ...seriesItems];
+    if (this.status) this.status = { ...this.status, queue: newQueue };
+    const last = this.queue.length - 1;
+    try {
+      for (let i = 0; i < seriesItems.length; i++) {
+        await reorderDownload(seriesItems[i].chapter.id, last - (seriesItems.length - 1 - i));
+      }
+      await this.poll();
+    } catch { await this.poll(); }
+    finally { this.batchWorking = false; }
+  }
+
+  async reverseSeriesOrder(items: DownloadQueueItem[]) {
+    if (this.batchWorking || items.length <= 1) return;
+    this.batchWorking = true;
+    const seriesIdSet = new Set(items.map(i => i.chapter.id));
+    const seriesIndices = this.queue
+      .map((item, i) => ({ id: item.chapter.id, i }))
+      .filter(({ id }) => seriesIdSet.has(id))
+      .map(({ i }) => i);
+
+    const reversedItems = items.slice().reverse();
+    const newQueue = [...this.queue];
+    for (let k = 0; k < seriesIndices.length; k++) {
+      newQueue[seriesIndices[k]] = reversedItems[k];
+    }
+    if (this.status) this.status = { ...this.status, queue: newQueue };
+    try {
+      for (let k = 0; k < seriesIndices.length; k++) {
+        await reorderDownload(reversedItems[k].chapter.id, seriesIndices[k]);
+      }
+      await this.poll();
+    } catch { await this.poll(); }
+    finally { this.batchWorking = false; }
+  }
+
   selectOnly(chapterId: number)   { this.selected = new Set([chapterId]); }
   toggleSelect(chapterId: number) {
     const next = new Set(this.selected);

--- a/src/lib/state/history.svelte.ts
+++ b/src/lib/state/history.svelte.ts
@@ -154,6 +154,12 @@ class HistoryStore {
     void this._persist()
   }
 
+  clearMangaHistory(mangaId: number) {
+    this.sessions = this.sessions.filter(s => s.mangaId !== mangaId)
+    this.stats    = computeStats(this.sessions)
+    void this._persist()
+  }
+
   private _commit(endedAt: number) {
     const a = this.active
     if (!a) return


### PR DESCRIPTION
feat(history): collapse series history, reorder tabs, and add per-series deletion

- Reorder top navigation tabs on Recent page to place History tab first and Updates tab second, setting History as default active tab.
- Collapse reading sessions per manga/manhwa into a single card in the History tab.
- Add expandable chapter dropdown to each series card, collapsing repeated chapter reads and opening chapters directly in the reader.
- Add per-series deletion with a confirmation modal overlay to clear history for individual manga.
<img width="1854" height="976" alt="Screenshot 2026-08-12 111029" src="https://github.com/user-attachments/assets/23477dd6-b5fb-46d8-b759-eb986539ab41" />
