### PR TITLE
Feat: Parallel download pre-caching + download queue fixes

### DIFF
--- a/src/lib/components/downloads/DownloadItem.svelte
+++ b/src/lib/components/downloads/DownloadItem.svelte
@@ -1,9 +1,10 @@
 <script lang="ts">
-  import { CircleNotchIcon, ArrowClockwiseIcon, XIcon } from "phosphor-svelte";
+  import { CircleNotchIcon, ArrowClockwiseIcon, XIcon, LightningIcon } from "phosphor-svelte";
   import Thumbnail    from "$lib/components/shared/manga/Thumbnail.svelte";
   import { longPress } from "$lib/core/ui/touchscreen";
   import type { DownloadQueueItem } from "$lib/types/api";
   import { pageProgress } from "$lib/components/downloads/lib/downloadQueue";
+  import { warmProgress } from "$lib/components/downloads/lib/warmPages";
 
   interface Props {
     item:       DownloadQueueItem;
@@ -24,6 +25,8 @@
   const pages   = $derived(item.chapter.pageCount ?? 0);
   const prog    = $derived(pageProgress(item.progress, pages));
   const isError = $derived(item.state === "ERROR");
+  const warmPct = $derived(item.state === "QUEUED" && !isActive ? Math.round(warmProgress(item.chapter.id) * 100) : 0);
+  const isWarm  = $derived(warmProgress(item.chapter.id) > 0);
   const pct     = $derived(Math.round(item.progress * 100));
 
   function rowLongPress(node: HTMLElement) {
@@ -58,14 +61,20 @@
     {#if pages > 0}
       <div class="progress-row">
         <div class="progress-wrap">
-          <div class="progress-bar" class:progress-error={isError} style="width:{pct}%"></div>
+          {#if warmPct > 0}
+            <div class="progress-bar warm-bar" style="width:{warmPct}%"></div>
+          {:else}
+            <div class="progress-bar" class:progress-error={isError} style="width:{pct}%"></div>
+          {/if}
         </div>
         <span class="pages-label">
           {#if isActive}
+            {#if isWarm}<span class="warm-wrap" title="Pre-cached — finishing quickly"><LightningIcon size={9} weight="fill" class="warm-icon" /></span>{/if}
             {prog.done}/{prog.total}
           {:else if isError}
             failed · {item.tries} {item.tries === 1 ? "try" : "tries"}
           {:else}
+            {#if isWarm}<span class="warm-wrap" title="Pre-cached — will finish quickly"><LightningIcon size={9} weight="fill" class="warm-icon" /></span>{/if}
             {prog.total}p
           {/if}
         </span>
@@ -113,9 +122,12 @@
   .progress-row  { display: flex; align-items: center; gap: var(--sp-2); }
   .progress-wrap { flex: 1; height: 2px; background: var(--border-base); border-radius: var(--radius-full); overflow: hidden; }
   .progress-bar  { height: 100%; background: var(--accent); border-radius: var(--radius-full); transition: width 0.4s ease; opacity: 0.35; }
+  .progress-bar.warm-bar { background: var(--color-info); opacity: 0.8; }
   .row-active .progress-bar { opacity: 1; }
   .progress-bar.progress-error { background: var(--color-error); opacity: 0.7; }
-  .pages-label { font-family: var(--font-ui); font-size: var(--text-2xs); color: var(--text-faint); letter-spacing: var(--tracking-wide); flex-shrink: 0; white-space: nowrap; }
+  .pages-label { font-family: var(--font-ui); font-size: var(--text-2xs); color: var(--text-faint); letter-spacing: var(--tracking-wide); flex-shrink: 0; white-space: nowrap; display: inline-flex; align-items: center; gap: 3px; }
+  .warm-wrap { display: inline-flex; }
+  .warm-icon { color: var(--color-info); }
   .row-active .pages-label { color: var(--accent-fg); opacity: 0.8; }
 
   .row-right  { display: flex; flex-direction: column; align-items: flex-end; gap: var(--sp-1); flex-shrink: 0; }

--- a/src/lib/components/downloads/DownloadQueue.svelte
+++ b/src/lib/components/downloads/DownloadQueue.svelte
@@ -1,9 +1,10 @@
 <script lang="ts">
-  import { CircleNotchIcon, CaretUp, CaretDown, CaretRight, Trash, ArrowClockwise, X, ArrowLineUp, ArrowLineDown, ArrowsDownUp } from "phosphor-svelte";
+  import { CircleNotchIcon, CaretUp, CaretDown, CaretRight, Trash, ArrowClockwise, X, ArrowLineUp, ArrowLineDown, ArrowsDownUp, LightningIcon } from "phosphor-svelte";
   import Thumbnail    from "$lib/components/shared/manga/Thumbnail.svelte";
   import DownloadItem    from "$lib/components/downloads/DownloadItem.svelte";
   import ContextMenu, { type MenuEntry } from "$lib/components/shared/ui/ContextMenu.svelte";
   import { downloadStore } from "$lib/state/downloads.svelte";
+  import { warmProgress }  from "$lib/components/downloads/lib/warmPages";
   import type { DownloadQueueItem } from "$lib/types/api";
 
   interface Props {
@@ -13,13 +14,14 @@
     dequeueing: Set<number>;
     selected:   Set<number>;
     onRemove: (chapterId: number) => void;
+    onRemoveMany: (chapterIds: number[]) => void;
     onRetry:  (chapterId: number) => void;
     onSelect: (chapterId: number, e: MouseEvent) => void;
   }
 
   const {
     queue, loading, isRunning, dequeueing, selected,
-    onRemove, onRetry, onSelect,
+    onRemove, onRemoveMany, onRetry, onSelect,
   }: Props = $props();
 
   let expandedSeriesIds: Set<number> = $state(new Set());
@@ -34,6 +36,8 @@
     seriesPct:         number;
     activeChapter:     DownloadQueueItem | null;
     activeChapterPct:  number;
+    activeIsWarm:      boolean;
+    activeWarmBar:     boolean;
     activeChapterName: string;
     isDownloading:     boolean;
     hasError:          boolean;
@@ -58,7 +62,14 @@
 
       const downloading = items.find(i => i.state === "DOWNLOADING");
       const active = downloading ?? items.find(i => (i.progress ?? 0) > 0) ?? items[0];
-      const activePct = active ? Math.round((active.progress ?? 0) * 100) : 0;
+      const activeWarm = !!active && warmProgress(active.chapter.id) > 0;
+      // blue precache bar only while still queued; once downloading show real progress but keep the bolt
+      const activeWarmBar = activeWarm && active!.state === "QUEUED" && !downloading;
+      const activePct = active
+        ? (activeWarmBar
+            ? Math.round(warmProgress(active.chapter.id) * 100)
+            : Math.round((active.progress ?? 0) * 100))
+        : 0;
 
       groups.push({
         mangaId,
@@ -68,6 +79,8 @@
         seriesPct,
         activeChapter:     active,
         activeChapterPct:  activePct,
+        activeIsWarm:      activeWarm,
+        activeWarmBar,
         activeChapterName: active ? active.chapter.name : "",
         isDownloading:     items.some(i => i.state === "DOWNLOADING"),
         hasError:          items.some(i => i.state === "ERROR"),
@@ -185,6 +198,9 @@
           <div class="series-info">
             <div class="series-title-row">
               <span class="series-title">{group.mangaTitle}</span>
+              {#if group.activeIsWarm}
+                <span class="warm-wrap" title="Next chapter pre-cached — will finish quickly"><LightningIcon size={9} weight="fill" class="warm-icon" /></span>
+              {/if}
               <span class="series-count-badge">{group.items.length} {group.items.length === 1 ? "chapter" : "chapters"}</span>
             </div>
 
@@ -195,7 +211,7 @@
                     Current ({group.activeChapterName}):
                   </span>
                   <div class="prog-track">
-                    <div class="prog-fill" style="width: {group.activeChapterPct}%"></div>
+                    <div class="prog-fill" class:is-warm={group.activeWarmBar} style="width: {group.activeChapterPct}%"></div>
                   </div>
                   <span class="prog-pct">{group.activeChapterPct}%</span>
                 </div>
@@ -260,7 +276,7 @@
           class="btn-danger"
           onclick={() => {
             if (confirmDeleteSeries) {
-              confirmDeleteSeries.items.forEach(i => onRemove(i.chapter.id));
+              onRemoveMany(confirmDeleteSeries.items.map(i => i.chapter.id));
             }
             confirmDeleteSeries = null;
           }}
@@ -312,12 +328,15 @@
   .series-title-row { display: flex; align-items: center; gap: var(--sp-2); min-width: 0; }
   .series-title { font-size: var(--text-sm); font-weight: var(--weight-medium); color: var(--text-primary); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
   .series-count-badge { font-family: var(--font-ui); font-size: var(--text-2xs); color: var(--text-faint); opacity: 0.7; flex-shrink: 0; white-space: nowrap; }
+  .warm-icon { color: var(--color-info); flex-shrink: 0; }
+  .warm-wrap { display: inline-flex; flex-shrink: 0; }
 
   .series-prog-container { display: flex; flex-direction: column; gap: 3px; margin-top: 2px; }
   .prog-item { display: flex; align-items: center; gap: var(--sp-2); }
   .prog-label { font-family: var(--font-ui); font-size: 10px; color: var(--text-muted); min-width: 85px; max-width: 160px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; flex-shrink: 0; }
   .prog-track { flex: 1; height: 3px; background: var(--border-base); border-radius: var(--radius-full); overflow: hidden; }
   .prog-fill { height: 100%; background: var(--accent); border-radius: var(--radius-full); transition: width 0.3s ease; }
+  .prog-fill.is-warm { background: var(--color-info); }
   .prog-fill.series-fill { background: color-mix(in srgb, var(--accent) 70%, #3b82f6); }
   .prog-pct { font-family: var(--font-ui); font-size: 10px; font-weight: 600; color: var(--accent-fg); min-width: 28px; text-align: right; flex-shrink: 0; }
 

--- a/src/lib/components/downloads/Downloads.svelte
+++ b/src/lib/components/downloads/Downloads.svelte
@@ -7,6 +7,7 @@
 
   let selectAnchor = $state<number | null>(null);
   let moveBy       = $state(1);
+  let confirmClear = $state(false);
 
   const selectedErrorCount = $derived(
     downloadStore.queue.filter(i => downloadStore.selected.has(i.chapter.id) && i.state === "ERROR").length,
@@ -92,7 +93,7 @@
       <button
         class="icon-btn"
         class:loading={downloadStore.clearing}
-        onclick={() => downloadStore.clear()}
+        onclick={() => confirmClear = true}
         disabled={downloadStore.clearing || downloadStore.queue.length === 0}
         title="Clear queue"
       >
@@ -166,11 +167,52 @@
       dequeueing={downloadStore.dequeueing}
       selected={downloadStore.selected}
       onRemove={(id: number) => downloadStore.dequeue(id)}
+      onRemoveMany={(ids: number[]) => downloadStore.dequeueMany(ids)}
       onRetry={(id: number) => downloadStore.retryOne(id)}
       onSelect={handleSelect}
     />
   </div>
 </div>
+
+{#if confirmClear}
+  <div
+    class="modal-backdrop"
+    role="presentation"
+    onclick={() => confirmClear = false}
+    onkeydown={(e) => e.key === 'Escape' && (confirmClear = false)}
+  >
+    <div class="modal-card" role="dialog" aria-modal="true" onclick={(e) => e.stopPropagation()}>
+      <div class="modal-header">
+        <span class="modal-title">Clear download queue?</span>
+      </div>
+      <div class="modal-body">
+        <p class="modal-msg">Remove all <strong>{downloadStore.queue.length}</strong> queued downloads? Chapters that are already downloaded on the server are not affected.</p>
+      </div>
+      <div class="modal-actions">
+        <button class="btn-cancel" onclick={() => confirmClear = false}>Cancel</button>
+        <button
+          class="btn-danger"
+          onclick={() => { confirmClear = false; downloadStore.clear(); }}
+        >
+          Clear queue
+        </button>
+      </div>
+    </div>
+  </div>
+{/if}
+
+{#if downloadStore.reorderProgress}
+  <div class="reorder-toast" role="status" aria-live="polite">
+    <CircleNotch size={14} weight="light" class="anim-spin" />
+    <span class="reorder-text">
+      Reordering {downloadStore.reorderProgress.current + 1}/{downloadStore.reorderProgress.total}
+      <span class="reorder-chapter">{downloadStore.reorderProgress.chapterName}</span>
+    </span>
+    <button class="reorder-cancel" onclick={() => downloadStore.cancelReorder()} title="Cancel reorder">
+      <X size={12} weight="bold" />
+    </button>
+  </div>
+{/if}
 
 <style>
   .root { display: flex; flex-direction: column; height: 100%; overflow: hidden; animation: fadeIn 0.14s ease both; }
@@ -221,6 +263,69 @@
   .move-input::-webkit-outer-spin-button, .move-input::-webkit-inner-spin-button { -webkit-appearance: none; }
   .move-input:focus { color: var(--text-primary); }
 
+  .modal-backdrop {
+    position: fixed; inset: 0; z-index: 1000;
+    background: rgba(0, 0, 0, 0.5);
+    display: flex; align-items: center; justify-content: center;
+    animation: fadeIn 0.12s ease both;
+  }
+  .modal-card {
+    background: var(--bg-surface); border: 1px solid var(--border-base);
+    border-radius: var(--radius-lg); width: 340px; max-width: 90vw;
+    box-shadow: 0 8px 32px rgba(0, 0, 0, 0.5); overflow: hidden;
+    display: flex; flex-direction: column;
+  }
+  .modal-header { padding: var(--sp-4) var(--sp-4) var(--sp-2); }
+  .modal-title  { font-size: var(--text-sm); font-weight: var(--weight-medium); color: var(--text-primary); }
+  .modal-body   { padding: 0 var(--sp-4) var(--sp-4); }
+  .modal-msg    { font-family: var(--font-ui); font-size: var(--text-xs); color: var(--text-muted); line-height: 1.4; margin: 0; }
+  .modal-actions {
+    display: flex; align-items: center; justify-content: flex-end; gap: var(--sp-2);
+    padding: var(--sp-3) var(--sp-4); border-top: 1px solid var(--border-dim); background: var(--bg-raised);
+  }
+  .btn-cancel, .btn-danger {
+    font-family: var(--font-ui); font-size: var(--text-xs); letter-spacing: var(--tracking-wide);
+    padding: 5px 12px; border-radius: var(--radius-sm); cursor: pointer;
+    transition: background var(--t-base), color var(--t-base), border-color var(--t-base);
+  }
+  .btn-cancel { border: 1px solid var(--border-dim); background: none; color: var(--text-muted); }
+  .btn-cancel:hover { color: var(--text-primary); border-color: var(--border-strong); }
+  .btn-danger {
+    border: 1px solid color-mix(in srgb, var(--color-error) 40%, transparent);
+    background: var(--color-error-bg); color: var(--color-error);
+  }
+  .btn-danger:hover {
+    background: color-mix(in srgb, var(--color-error) 20%, transparent);
+    border-color: var(--color-error);
+  }
+
   @keyframes pulse  { 0%, 100% { opacity: 1 } 50% { opacity: 0.4 } }
   @keyframes fadeIn { from { opacity: 0 } to { opacity: 1 } }
+
+  .reorder-toast {
+    position: fixed; bottom: var(--sp-6); right: var(--sp-6); z-index: 900;
+    display: flex; align-items: center; gap: var(--sp-2);
+    padding: var(--sp-2) var(--sp-4);
+    background: var(--bg-surface); border: 1px solid var(--border-strong);
+    border-radius: var(--radius-md); box-shadow: 0 4px 16px rgba(0,0,0,0.4);
+    animation: fadeIn 0.12s ease both;
+    color: var(--text-muted);
+  }
+  .reorder-text {
+    font-family: var(--font-ui); font-size: var(--text-xs);
+    letter-spacing: var(--tracking-wide); white-space: nowrap;
+    display: inline-flex; align-items: center; gap: var(--sp-2);
+  }
+  .reorder-chapter {
+    color: var(--text-faint); max-width: 200px;
+    overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+  }
+  .reorder-cancel {
+    display: flex; align-items: center; justify-content: center;
+    width: 20px; height: 20px; border-radius: var(--radius-sm);
+    border: 1px solid var(--border-dim); background: none;
+    color: var(--text-faint); cursor: pointer; flex-shrink: 0;
+    transition: color var(--t-base), border-color var(--t-base), background var(--t-base);
+  }
+  .reorder-cancel:hover { color: var(--color-error); border-color: color-mix(in srgb, var(--color-error) 40%, transparent); background: color-mix(in srgb, var(--color-error) 8%, transparent); }
 </style>

--- a/src/lib/components/downloads/lib/warmPages.ts
+++ b/src/lib/components/downloads/lib/warmPages.ts
@@ -1,0 +1,318 @@
+import { fetchPages }       from "$lib/core/cache/pageCache";
+import { platformService }  from "$lib/platform-service";
+import { authHeaders }      from "$lib/core/auth";
+import { settingsState }    from "$lib/state/settings.svelte";
+import type { DownloadQueueItem } from "$lib/types/api";
+
+// CONCURRENCY:  max simultaneous page-image fetches.
+// CHAPTERS_MAX: max chapters in the warming pipeline at once.
+// COLD_BUFFER:  same-source chapters ahead of the warm frontier stay cold to avoid racing the downloader's cache writes.
+// Values come from Settings (Storage tab); these are the fallbacks before settings load.
+const CONCURRENCY  = 8;
+const CHAPTERS_MAX = 5;
+const COLD_BUFFER  = 2;
+const MAX_ATTEMPTS = 3;
+
+function warmingEnabled(): boolean { return settingsState.settings.warmingEnabled ?? true; }
+function chapterMax(): number      { return Math.max(1, settingsState.settings.warmingChaptersMax ?? CHAPTERS_MAX); }
+function coldBuffer(): number      { return Math.max(0, settingsState.settings.warmingColdBuffer ?? COLD_BUFFER); }
+function concurrency(): number     { return Math.max(1, settingsState.settings.warmingConcurrency ?? CONCURRENCY); }
+
+// Persist warmed-chapter tracking across reloads/pause; pages themselves live in the Suwayomi cache.
+const WARMED_KEY = "moku:warmed-chapters";
+function loadWarmed(): Set<number> {
+  try { const raw = localStorage.getItem(WARMED_KEY); if (raw) return new Set(JSON.parse(raw)); } catch {}
+  return new Set<number>();
+}
+function saveWarmed(): void {
+  try { localStorage.setItem(WARMED_KEY, JSON.stringify([...warmed])); } catch {}
+}
+const warmed = loadWarmed();
+const failed   = new Set<number>();
+const inflight = new Map<number, AbortController>(); // page-list fetches in flight
+const pending  = new Map<number, number>();           // chapterId → pages left to complete
+const totals   = new Map<number, number>();           // chapterId → total pages
+const attempts = new Map<number, number>();
+
+// Per-chapter remaining image URLs plus warm order; the worker round-robins across warmOrder so chapters warm in parallel.
+const chapterUrls: Map<number, string[]> = new Map();
+const warmOrder: number[] = [];
+let running = 0;
+
+let paused = false;
+
+// Page-list fetches are sequential to limit WebView pool pressure.
+const pageListQueue: number[] = [];
+let pageListFetching = false;
+
+// Last polled state/queue; lets the worker refill immediately on chapter finish.
+let lastState = "";
+let lastQueue: DownloadQueueItem[] = [];
+
+let conversionsChecked = false;
+let conversionsOn      = false;
+let conversionsPending = false;
+
+async function ensureConversionsChecked(): Promise<boolean> {
+  if (conversionsChecked) return conversionsOn;
+  if (conversionsPending) return false;
+  conversionsPending = true;
+  try {
+    const base = (settingsState.settings.serverUrl ?? "http://localhost:4567").replace(/\/$/, "");
+    const res = await fetch(`${base}/api/graphql`, {
+      method:  "POST",
+      headers: { "Content-Type": "application/json", ...authHeaders() },
+      body:    JSON.stringify({ query: "{ settings { downloadConversions { target } } }" }),
+    });
+    if (!res.ok) return false;
+    const json = await res.json();
+    if (json?.errors?.length) { conversionsChecked = true; conversionsOn = true; return true; }
+    conversionsOn      = ((json?.data?.settings?.downloadConversions?.length ?? 0) > 0);
+    conversionsChecked = true;
+    return conversionsOn;
+  } catch {
+    return false;
+  } finally {
+    conversionsPending = false;
+  }
+}
+
+// Pops one image per chapter per cycle so all chapters warm in parallel; on finish, refills via maybeWarmMore(). A chapter is only marked warmed when every page fetch returned image bytes (which is what makes Suwayomi skip it) — failed/empty fetches are retried, and the chapter is abandoned unwarmed if too many fail.
+function worker(): void {
+  while (running < concurrency()) {
+    let started = false;
+    for (let i = 0; i < warmOrder.length; i++) {
+      const id = warmOrder[i];
+      const urls = chapterUrls.get(id);
+      if (!urls || urls.length === 0) continue;
+      const url = urls.shift()!;
+      running++;
+      started = true;
+      platformService.fetchImage(url, authHeaders())
+        .then(blob => {
+          running--;
+          if (blob.size > 0) {
+            // page actually cached on the server — count it
+            if (pending.has(id)) {
+              const left = pending.get(id)! - 1;
+              if (left <= 0) {
+                pending.delete(id);
+                totals.delete(id);
+                chapterUrls.delete(id);
+                const idx = warmOrder.indexOf(id);
+                if (idx >= 0) warmOrder.splice(idx, 1);
+                warmed.add(id);
+                saveWarmed();
+                maybeWarmMore(); // chapter finished — start the next one
+              } else {
+                pending.set(id, left);
+              }
+            }
+          } else {
+            // resolvable but empty — treat as a failed page
+            retryOrAbandon(id, url);
+          }
+          worker();
+        })
+        .catch(() => {
+          running--;
+          // Failed or empty page — didn't reach Suwayomi's cache, so it isn't warmed.
+          retryOrAbandon(id, url);
+          worker();
+        });
+    }
+    if (!started) break;
+  }
+}
+
+// Per-chapter count of failed page fetches while warming.
+const pageFails = new Map<number, number>();
+
+// A page fetch failed (or came back empty) — it didn't reach Suwayomi's cache. Retry once per page; abandon the whole chapter if the source keeps failing.
+function retryOrAbandon(chapterId: number, url: string): void {
+  const urls = chapterUrls.get(chapterId);
+  const total = totals.get(chapterId);
+  if (urls && total !== undefined) {
+    const fails = (pageFails.get(chapterId) ?? 0) + 1;
+    pageFails.set(chapterId, fails);
+    if (fails >= total) {
+      stopWarmChapter(chapterId); // stop pre-caching, let normal download handle it
+    } else {
+      urls.push(url); // retry this page later
+    }
+  }
+}
+
+// Abandon warming a chapter without marking it warmed (unreliable source).
+function stopWarmChapter(chapterId: number): void {
+  pageFails.delete(chapterId);
+  chapterUrls.delete(chapterId);
+  pending.delete(chapterId);
+  totals.delete(chapterId);
+  const idx = warmOrder.indexOf(chapterId);
+  if (idx >= 0) warmOrder.splice(idx, 1);
+  failed.add(chapterId);
+}
+
+function abortWarm(chapterId: number): void {
+  inflight.get(chapterId)?.abort();
+  inflight.delete(chapterId);
+  pending.delete(chapterId);
+  totals.delete(chapterId);
+  pageFails.delete(chapterId);
+  chapterUrls.delete(chapterId);
+  const wIdx = warmOrder.indexOf(chapterId);
+  if (wIdx >= 0) warmOrder.splice(wIdx, 1);
+  warmed.delete(chapterId);
+  saveWarmed();
+  failed.add(chapterId);
+  const qIdx = pageListQueue.indexOf(chapterId);
+  if (qIdx >= 0) pageListQueue.splice(qIdx, 1);
+}
+
+// Queue mutations (clear/remove) need WebViews; pause warming so the pool is free (image fetches don't use WebViews).
+export function pauseWarming(): void {
+  paused = true;
+  inflight.forEach(c => c.abort());
+  inflight.clear();
+  pageListQueue.length = 0;
+}
+
+export function resumeWarming(): void {
+  paused = false;
+  maybeWarmMore();
+}
+
+// Next chapter's page list from the queue, one at a time.
+async function fetchNextPageList(): Promise<void> {
+  if (pageListFetching || paused) return;
+  const id = pageListQueue.shift();
+  if (id === undefined) return;
+  pageListFetching = true;
+  const ctrl = new AbortController();
+  inflight.set(id, ctrl);
+  try {
+    const urls = await fetchPages(id, false, ctrl.signal);
+    if (paused) return;
+    if (!urls.length) {
+      warmed.add(id); saveWarmed();
+      maybeWarmMore();
+      return;
+    }
+    totals.set(id, urls.length);
+    pending.set(id, urls.length);
+    chapterUrls.set(id, urls);
+    warmOrder.push(id);
+    worker();
+  } catch {
+    if (!ctrl.signal.aborted) {
+      const n = (attempts.get(id) ?? 0) + 1;
+      attempts.set(id, n);
+      if (n >= MAX_ATTEMPTS) failed.add(id);
+    }
+  } finally {
+    inflight.delete(id);
+    pageListFetching = false;
+    if (pageListQueue.length && !paused) void fetchNextPageList();
+  }
+}
+
+// Chapters in the pipeline: page-list queued, being fetched, or downloading.
+function warmingCount(): number {
+  return pending.size + inflight.size + pageListQueue.length;
+}
+
+// Fill the pipeline up to chapterMax(); called on poll and when a chapter finishes.
+function maybeWarmMore(): void {
+  if (lastState !== "STARTED" || paused || !warmingEnabled()) return;
+  if (!conversionsChecked) {
+    void ensureConversionsChecked().then(() => maybeWarmMore());
+    return;
+  }
+  if (conversionsOn) return;
+  if (warmingCount() >= chapterMax()) return;
+
+  const coldPerSource = new Map<string, number>();
+  const erroredSources = new Set<string>();
+  let added = 0;
+  for (const item of lastQueue) {
+    const src = item.chapter.manga?.sourceId ?? "";
+    if (item.state === "ERROR") { erroredSources.add(src); continue; }
+    if (item.state !== "QUEUED" && item.state !== "DOWNLOADING") continue;
+    const id = item.chapter.id;
+    if (warmed.has(id) || pending.has(id) || inflight.has(id) ||
+        pageListQueue.includes(id) || chapterUrls.has(id)) continue;
+    const cold = (coldPerSource.get(src) ?? 0) + 1;
+    coldPerSource.set(src, cold);
+    if (item.state !== "QUEUED" || failed.has(id) || erroredSources.has(src)) continue;
+    if (cold > coldBuffer()) {
+      pageListQueue.push(id);
+      added++;
+      if (warmingCount() >= chapterMax()) break;
+    }
+  }
+  if (added > 0) void fetchNextPageList();
+}
+
+// Precache fraction for UI: 0 = not warming, 1 = fully pre-cached.
+export function warmProgress(chapterId: number): number {
+  if (warmed.has(chapterId)) return 1;
+  const left  = pending.get(chapterId);
+  const total = totals.get(chapterId);
+  if (left === undefined || !total) return 0;
+  return Math.min(1, (total - left) / total);
+}
+
+// Suwayomi's sequential downloader skips pages already in cache, so pre-caching queued chapters here in parallel speeds it up. A chapter is only warmed once COLD_BUFFER same-source chapters ahead still need a real download, so the warmer finishes writing before the downloader reaches it (a half-written page would corrupt the CBZ).
+export function warmDownloads(state: string, queue: DownloadQueueItem[]): void {
+  lastState = state;
+  lastQueue = queue;
+
+  if (state !== "STARTED") {
+    // Pause/stop: clear transient state but keep `warmed` — the cached pages survive on the server, so the UI indicator persists.
+    failed.clear();
+    pending.clear();
+    totals.clear();
+    attempts.clear();
+    pageFails.clear();
+    chapterUrls.clear();
+    warmOrder.length = 0;
+    pageListQueue.length = 0;
+    inflight.forEach(c => c.abort());
+    inflight.clear();
+    return;
+  }
+
+  // Chapters still in queue (queued or active) — exit set determines warmed pruning.
+  const activeIds = new Set(
+    queue.filter(i => i.state === "QUEUED" || i.state === "DOWNLOADING").map(i => i.chapter.id)
+  );
+  const queuedIds = new Set(
+    queue.filter(i => i.state === "QUEUED").map(i => i.chapter.id)
+  );
+  // Stop warming a chapter the downloader picked up — page writes would race the downloader's reads on cache files.
+  for (const id of [...inflight.keys(), ...pending.keys()]) {
+    if (!queuedIds.has(id)) abortWarm(id);
+  }
+  for (let i = pageListQueue.length - 1; i >= 0; i--) {
+    if (!queuedIds.has(pageListQueue[i])) pageListQueue.splice(i, 1);
+  }
+  // Prune warmed entries for chapters that left the queue (canceled/removed/finished-cleared).
+  let warmedChanged = false;
+  for (const id of warmed) {
+    if (!activeIds.has(id)) { warmed.delete(id); warmedChanged = true; }
+  }
+  if (warmedChanged) saveWarmed();
+  for (const id of failed) {
+    if (!activeIds.has(id)) failed.delete(id);
+  }
+  for (const id of [...totals.keys()]) {
+    if (!activeIds.has(id)) totals.delete(id);
+  }
+  for (const id of [...attempts.keys()]) {
+    if (!activeIds.has(id)) attempts.delete(id);
+  }
+  if (paused) return;
+
+  maybeWarmMore();
+}

--- a/src/lib/components/series/SeriesDetail.svelte
+++ b/src/lib/components/series/SeriesDetail.svelte
@@ -267,10 +267,8 @@
 
   async function enqueueMultiple(chapterIds: number[]) {
     if (!chapterIds.length) return
-    for (const id of chapterIds) {
-      const allowed = await downloadStore.enqueue(id)
-      if (!allowed) return
-    }
+    const allowed = await downloadStore.enqueueMany(chapterIds)
+    if (!allowed) return
     addToast({ kind: 'download', title: 'Download queued', body: `${chapterIds.length} chapter${chapterIds.length !== 1 ? 's' : ''} added` })
     seriesState.loadChapters(mangaId, { force: true })
   }

--- a/src/lib/components/settings/sections/StorageSettings.svelte
+++ b/src/lib/components/settings/sections/StorageSettings.svelte
@@ -558,6 +558,56 @@
   </div>
 
   <div class="s-section">
+    <p class="s-section-title">Warming</p>
+    <div class="s-section-body">
+      <label class="s-row">
+        <div class="s-row-info">
+          <span class="s-label">Pre-cache queued chapters</span>
+          <span class="s-desc">Fetches queued pages ahead so the downloader skips them — speeds up downloads</span>
+        </div>
+        <button role="switch" aria-checked={settingsState.settings.warmingEnabled ?? true} aria-label="Pre-cache queued chapters"
+          class="s-toggle" class:on={settingsState.settings.warmingEnabled ?? true}
+          onclick={() => updateSettings({ warmingEnabled: !(settingsState.settings.warmingEnabled ?? true) })}>
+          <span class="s-toggle-thumb"></span>
+        </button>
+      </label>
+      <div class="s-row">
+        <div class="s-row-info">
+          <span class="s-label">Parallel page fetches</span>
+          <span class="s-desc">Simultaneous page images fetched while pre-caching</span>
+        </div>
+        <div class="s-stepper">
+          <button class="s-step-btn" onclick={() => updateSettings({ warmingConcurrency: Math.max(1, (settingsState.settings.warmingConcurrency ?? 8) - 1) })} disabled={(settingsState.settings.warmingConcurrency ?? 8) <= 1}>−</button>
+          <span class="s-step-val">{settingsState.settings.warmingConcurrency ?? 8}</span>
+          <button class="s-step-btn" onclick={() => updateSettings({ warmingConcurrency: Math.min(32, (settingsState.settings.warmingConcurrency ?? 8) + 1) })} disabled={(settingsState.settings.warmingConcurrency ?? 8) >= 32}>+</button>
+        </div>
+      </div>
+      <div class="s-row">
+        <div class="s-row-info">
+          <span class="s-label">Chapters in pipeline</span>
+          <span class="s-desc">How many queued chapters pre-cache at once</span>
+        </div>
+        <div class="s-stepper">
+          <button class="s-step-btn" onclick={() => updateSettings({ warmingChaptersMax: Math.max(1, (settingsState.settings.warmingChaptersMax ?? 5) - 1) })} disabled={(settingsState.settings.warmingChaptersMax ?? 5) <= 1}>−</button>
+          <span class="s-step-val">{settingsState.settings.warmingChaptersMax ?? 5}</span>
+          <button class="s-step-btn" onclick={() => updateSettings({ warmingChaptersMax: Math.min(20, (settingsState.settings.warmingChaptersMax ?? 5) + 1) })} disabled={(settingsState.settings.warmingChaptersMax ?? 5) >= 20}>+</button>
+        </div>
+      </div>
+      <div class="s-row">
+        <div class="s-row-info">
+          <span class="s-label">Cold buffer</span>
+          <span class="s-desc">Chapters ahead of the warm frontier kept unwarmed to avoid racing the downloader</span>
+        </div>
+        <div class="s-stepper">
+          <button class="s-step-btn" onclick={() => updateSettings({ warmingColdBuffer: Math.max(0, (settingsState.settings.warmingColdBuffer ?? 2) - 1) })} disabled={(settingsState.settings.warmingColdBuffer ?? 2) <= 0}>−</button>
+          <span class="s-step-val">{settingsState.settings.warmingColdBuffer ?? 2}</span>
+          <button class="s-step-btn" onclick={() => updateSettings({ warmingColdBuffer: Math.min(10, (settingsState.settings.warmingColdBuffer ?? 2) + 1) })} disabled={(settingsState.settings.warmingColdBuffer ?? 2) >= 10}>+</button>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div class="s-section">
     <button class="s-collapsible-trigger" onclick={() => advStorageOpen = !advStorageOpen}>
       <span class="s-label">Advanced</span>
       <svg class="s-collapsible-caret" class:open={advStorageOpen} width="10" height="6" viewBox="0 0 10 6"><path d="M0 0l5 6 5-6" fill="currentColor"/></svg>

--- a/src/lib/request-manager/downloads.ts
+++ b/src/lib/request-manager/downloads.ts
@@ -34,6 +34,10 @@ export async function reorderDownload(chapterId: number, to: number): Promise<Do
   }
 }
 
+export async function reorderDownloadLight(chapterId: number, to: number, signal?: AbortSignal): Promise<void> {
+  await getAdapter().reorderDownloadLight(String(chapterId), to, signal);
+}
+
 export async function clearDownloads(): Promise<void> {
   await getAdapter().clearDownloads();
 }

--- a/src/lib/server-adapters/suwayomi/downloads.ts
+++ b/src/lib/server-adapters/suwayomi/downloads.ts
@@ -4,7 +4,7 @@ const QUEUE_FRAGMENT = `
     progress state tries
     chapter {
       id name pageCount mangaId
-      manga { id title thumbnailUrl }
+      manga { id title thumbnailUrl sourceId }
     }
   }
 `
@@ -51,6 +51,15 @@ export const REORDER_DOWNLOAD = `
   mutation ReorderDownload($chapterId: Int!, $to: Int!) {
     reorderChapterDownload(input: { chapterId: $chapterId, to: $to }) {
       downloadStatus { ${QUEUE_FRAGMENT} }
+    }
+  }
+`
+
+// Lightweight version: returns only state, not the full queue, for batch reorders where the response is discarded (final poll fetches state). Avoids downloading the whole queue per call.
+export const REORDER_DOWNLOAD_LIGHT = `
+  mutation ReorderDownload($chapterId: Int!, $to: Int!) {
+    reorderChapterDownload(input: { chapterId: $chapterId, to: $to }) {
+      downloadStatus { state }
     }
   }
 `

--- a/src/lib/server-adapters/suwayomi/index.ts
+++ b/src/lib/server-adapters/suwayomi/index.ts
@@ -67,6 +67,7 @@ import {
   DEQUEUE_DOWNLOAD,
   DEQUEUE_CHAPTERS_DOWNLOAD,
   REORDER_DOWNLOAD,
+  REORDER_DOWNLOAD_LIGHT,
   START_DOWNLOADER,
   STOP_DOWNLOADER,
   CLEAR_DOWNLOADER,
@@ -128,6 +129,11 @@ import {
 import { initPageCache, clearPageCache as _clearPageCache } from './pageCache'
 
 type RawQueueItem = Record<string, unknown>
+
+// download queue mutations can stall while the server's WebView pool is saturated; bound them so the client can retry instead of hanging
+function mutationTimeout(): AbortSignal | undefined {
+  return typeof AbortSignal !== "undefined" && "timeout" in AbortSignal ? AbortSignal.timeout(10_000) : undefined
+}
 
 function mapDownloadStatus(raw: { state: string; queue: RawQueueItem[] }): DownloadStatus {
   return {
@@ -389,11 +395,11 @@ export class SuwayomiAdapter implements ServerAdapter {
   }
 
   async dequeueDownload(chapterId: string): Promise<void> {
-    await this.gql(DEQUEUE_DOWNLOAD, { chapterId: Number(chapterId) })
+    await this.gql(DEQUEUE_DOWNLOAD, { chapterId: Number(chapterId) }, mutationTimeout())
   }
 
   async dequeueDownloads(chapterIds: string[]): Promise<void> {
-    await this.gql(DEQUEUE_CHAPTERS_DOWNLOAD, { chapterIds: chapterIds.map(Number) })
+    await this.gql(DEQUEUE_CHAPTERS_DOWNLOAD, { chapterIds: chapterIds.map(Number) }, mutationTimeout())
   }
 
   async reorderDownload(chapterId: string, to: number): Promise<DownloadStatus | null> {
@@ -405,8 +411,13 @@ export class SuwayomiAdapter implements ServerAdapter {
     } catch { return null }
   }
 
+  // Lightweight batch reorder: returns only state (not full queue), cancelled via AbortSignal.
+  async reorderDownloadLight(chapterId: string, to: number, signal?: AbortSignal): Promise<void> {
+    await this.gql(REORDER_DOWNLOAD_LIGHT, { chapterId: Number(chapterId), to }, signal)
+  }
+
   async clearDownloads(): Promise<void> {
-    await this.gql(CLEAR_DOWNLOADER)
+    await this.gql(CLEAR_DOWNLOADER, undefined, mutationTimeout())
   }
 
   async startDownloader(): Promise<DownloadStatus | null> {

--- a/src/lib/server-adapters/types.ts
+++ b/src/lib/server-adapters/types.ts
@@ -179,6 +179,7 @@ export interface ServerAdapter {
   dequeueDownload(chapterId: string): Promise<void>
   dequeueDownloads(chapterIds: string[]): Promise<void>
   reorderDownload(chapterId: string, to: number): Promise<DownloadStatus | null>
+  reorderDownloadLight(chapterId: string, to: number, signal?: AbortSignal): Promise<void>
   clearDownloads(): Promise<void>
   startDownloader(): Promise<DownloadStatus | null>
   stopDownloader(): Promise<DownloadStatus | null>

--- a/src/lib/state/downloads.svelte.ts
+++ b/src/lib/state/downloads.svelte.ts
@@ -1,7 +1,7 @@
 import type { DownloadStatus, DownloadQueueItem } from "$lib/types/api";
 import {
   loadDownloadStatus, dequeueDownload, dequeueDownloads,
-  reorderDownload, clearDownloads, startDownloader, stopDownloader, enqueueDownload,
+  reorderDownload, reorderDownloadLight, clearDownloads, startDownloader, stopDownloader, enqueueDownload, enqueueDownloads,
   getStorageInfo,
 } from "$lib/request-manager/downloads";
 import { settingsState, updateSettings } from "$lib/state/settings.svelte";
@@ -11,6 +11,7 @@ import {
   type SpeedSample,
 } from "$lib/components/downloads/lib/downloadQueue";
 import { startAutoRetry, type AutoRetryHandle } from "$lib/components/downloads/lib/autoRetry";
+import { warmDownloads, pauseWarming, resumeWarming } from "$lib/components/downloads/lib/warmPages";
 import { mount, unmount }                        from "svelte";
 import StorageWarningDialog                       from "$lib/components/downloads/StorageWarningDialog.svelte";
 
@@ -22,6 +23,8 @@ class DownloadStore {
   dequeueing                           = $state(new Set<number>());
   selected                             = $state(new Set<number>());
   batchWorking                         = $state(false);
+  reorderProgress: { current: number; total: number; chapterName: string } | null = $state(null);
+  private reorderAbort: AbortController | null = null;
   pagesPerSec:   number | null         = $state(null);
   eta:           number | null         = $state(null);
   storageWarning                       = $state(false);
@@ -30,9 +33,35 @@ class DownloadStore {
   private lastSample:   SpeedSample | null = null;
   private prevQueue:    DownloadQueueItem[] = [];
   private autoRetryHnd: AutoRetryHandle | null = null;
+  private forceStop = false;
+  private stopping  = false;
 
   get queue()            { return this.status?.queue ?? []; }
   get isRunning()        { return isRunning(this.status?.state); }
+
+  // Run a batch of sequential reorderDownload calls, updating reorderProgress for a live UI popup; uses the lightweight mutation (state only) and is cancellable via cancelReorder().
+  private async batchReorder(
+    ops: { chapterId: number; to: number; chapterName: string }[],
+  ): Promise<void> {
+    this.reorderAbort = new AbortController();
+    this.reorderProgress = { current: 0, total: ops.length, chapterName: ops[0]?.chapterName ?? "" };
+    try {
+      for (let i = 0; i < ops.length; i++) {
+        if (this.reorderAbort.signal.aborted) break;
+        this.reorderProgress = { current: i, total: ops.length, chapterName: ops[i].chapterName };
+        await reorderDownloadLight(ops[i].chapterId, ops[i].to, this.reorderAbort.signal);
+      }
+    } catch {
+      // aborted or network error — stop gracefully
+    } finally {
+      this.reorderAbort = null;
+      this.reorderProgress = null;
+    }
+  }
+
+  cancelReorder() {
+    this.reorderAbort?.abort();
+  }
   get erroredIds()       { return new Set(getErrored(this.queue).map(i => i.chapter.id)); }
   get hasErrored()       { return this.erroredIds.size > 0; }
   get toastsEnabled()    { return settingsState.settings.downloadToastsEnabled ?? true; }
@@ -43,6 +72,13 @@ class DownloadStore {
     this.status = ds;
     this.updateSpeed(ds);
     this.syncFreeBytes(ds);
+    warmDownloads(ds.state, ds.queue);
+    if (this.forceStop && ds.state === "STARTED" && !this.stopping) {
+      this.stopping = true;
+      stopDownloader()
+        .catch(() => {})
+        .finally(() => { this.stopping = false; });
+    }
   }
 
   private updateSpeed(ds: DownloadStatus) {
@@ -118,6 +154,20 @@ class DownloadStore {
     return true;
   }
 
+  async enqueueMany(chapterIds: number[]): Promise<boolean> {
+    if (!chapterIds.length) return true;
+    const projected = [
+      ...this.queue,
+      ...chapterIds.map(id => ({ chapter: { id, pageCount: 0 }, progress: 0, state: "QUEUED" } as DownloadQueueItem)),
+    ];
+    if (!(await this.guardStorage(projected))) return false;
+    try {
+      await enqueueDownloads(chapterIds.map(String));
+      await this.poll();
+    } catch { }
+    return true;
+  }
+
   toggleToasts() {
     const next = !this.toastsEnabled;
     updateSettings({ downloadToastsEnabled: next });
@@ -145,12 +195,26 @@ class DownloadStore {
     if (this.togglingPlay) return;
     this.togglingPlay = true;
     const wasRunning = this.isRunning;
+    this.forceStop = wasRunning;
     if (this.status) this.status = { ...this.status, state: wasRunning ? "STOPPED" : "STARTED" };
     try {
       const ds = wasRunning ? await stopDownloader() : await startDownloader();
+      if (!wasRunning) resumeWarming();
       if (ds) this.applyStatus(ds); else await this.poll();
     } catch { await this.poll(); }
     finally { this.togglingPlay = false; }
+  }
+
+  private async withRetry<T>(fn: () => Promise<T>): Promise<T> {
+    try { return await fn(); }
+    catch {
+      await new Promise(r => setTimeout(r, 1000));
+      return await fn();
+    }
+  }
+
+  private busyToast(title: string) {
+    addToast({ kind: "error", title, body: "The server is busy; try again in a moment.", duration: 4000 });
   }
 
   async clear() {
@@ -158,11 +222,15 @@ class DownloadStore {
     this.clearing = true;
     this.selected = new Set();
     if (this.status) this.status = { ...this.status, queue: [] };
+    pauseWarming();
     try {
-      await clearDownloads();
+      await this.withRetry(() => clearDownloads());
       addToast({ kind: "info", title: "Queue cleared", duration: 2500 });
-    } catch { await this.poll(); }
-    finally { this.clearing = false; }
+    } catch {
+      await this.poll();
+      this.busyToast("Failed to clear queue");
+    }
+    finally { this.clearing = false; if (this.isRunning) resumeWarming(); }
   }
 
   async dequeue(chapterId: number) {
@@ -170,24 +238,43 @@ class DownloadStore {
     this.dequeueing = new Set(this.dequeueing).add(chapterId);
     if (this.status) this.status = { ...this.status, queue: this.queue.filter(i => i.chapter.id !== chapterId) };
     const next = new Set(this.selected); next.delete(chapterId); this.selected = next;
-    try { await dequeueDownload(String(chapterId)); await this.poll(); }
-    catch { await this.poll(); }
-    finally { const s = new Set(this.dequeueing); s.delete(chapterId); this.dequeueing = s; }
+    pauseWarming();
+    try {
+      await this.withRetry(() => dequeueDownload(String(chapterId)));
+      await this.poll();
+    } catch {
+      await this.poll();
+      this.busyToast("Failed to remove download");
+    }
+    finally {
+      const s = new Set(this.dequeueing); s.delete(chapterId); this.dequeueing = s;
+      if (this.isRunning) resumeWarming();
+    }
+  }
+
+  async dequeueMany(chapterIds: number[]) {
+    if (this.batchWorking || !chapterIds.length) return;
+    this.batchWorking = true;
+    const idSet = new Set(chapterIds);
+    if (this.status) this.status = { ...this.status, queue: this.queue.filter(i => !idSet.has(i.chapter.id)) };
+    this.selected = new Set([...this.selected].filter(id => !idSet.has(id)));
+    pauseWarming();
+    try {
+      await this.withRetry(() => dequeueDownloads(chapterIds.map(String)));
+      await this.poll();
+      addToast({ kind: "info", title: `Removed ${chapterIds.length} download${chapterIds.length !== 1 ? "s" : ""}`, duration: 2500 });
+    } catch {
+      await this.poll();
+      this.busyToast("Failed to remove downloads");
+    }
+    finally { this.batchWorking = false; if (this.isRunning) resumeWarming(); }
   }
 
   async dequeueSelected() {
     if (this.batchWorking || !this.selected.size) return;
-    this.batchWorking = true;
-    const ids   = [...this.selected];
-    const idSet = new Set(ids);
+    const ids  = [...this.selected];
     this.selected = new Set();
-    if (this.status) this.status = { ...this.status, queue: this.queue.filter(i => !idSet.has(i.chapter.id)) };
-    try {
-      await dequeueDownloads(ids.map(String));
-      addToast({ kind: "info", title: `Removed ${ids.length} download${ids.length !== 1 ? "s" : ""}`, duration: 2500 });
-      await this.poll();
-    } catch { await this.poll(); }
-    finally { this.batchWorking = false; }
+    await this.dequeueMany(ids);
   }
 
   async retryOne(chapterId: number) {
@@ -270,10 +357,12 @@ class DownloadStore {
     }
     if (this.status) this.status = { ...this.status, queue: newQueue };
     try {
-      for (const idx of selectedIndices) {
-        const to = direction === "up" ? Math.max(0, idx - step) : Math.min(queue.length - 1, idx + step);
-        await reorderDownload(queue[idx].chapter.id, to);
-      }
+      const ops = selectedIndices.map(idx => ({
+        chapterId: queue[idx].chapter.id,
+        to: direction === "up" ? Math.max(0, idx - step) : Math.min(queue.length - 1, idx + step),
+        chapterName: queue[idx].chapter.name,
+      }));
+      await this.batchReorder(ops);
       await this.poll();
     } catch { await this.poll(); }
     finally { this.batchWorking = false; }
@@ -308,13 +397,12 @@ class DownloadStore {
     if (this.status) this.status = { ...this.status, queue: newQueue };
     const last = this.queue.length - 1;
     try {
-      if (edge === "top") {
-        for (let i = 0; i < pinned.length; i++)
-          await reorderDownload(pinned[i].chapter.id, first + i);
-      } else {
-        for (let i = 0; i < pinned.length; i++)
-          await reorderDownload(pinned[i].chapter.id, last - (pinned.length - 1 - i));
-      }
+      const ops = pinned.map((item, i) => ({
+        chapterId: item.chapter.id,
+        to: edge === "top" ? first + i : last - (pinned.length - 1 - i),
+        chapterName: item.chapter.name,
+      }));
+      await this.batchReorder(ops);
       await this.poll();
     } catch { await this.poll(); }
     finally { this.batchWorking = false; }
@@ -356,9 +444,12 @@ class DownloadStore {
     const newQueue = [...active, ...reorderedMoveable];
     if (this.status) this.status = { ...this.status, queue: newQueue };
     try {
-      for (let i = 0; i < reorderedMoveable.length; i++) {
-        await reorderDownload(reorderedMoveable[i].chapter.id, first + i);
-      }
+      const ops = reorderedMoveable.map((item, i) => ({
+        chapterId: item.chapter.id,
+        to: first + i,
+        chapterName: item.chapter.name,
+      }));
+      await this.batchReorder(ops);
       await this.poll();
     } catch { await this.poll(); }
     finally { this.batchWorking = false; }
@@ -376,9 +467,12 @@ class DownloadStore {
     const newQueue    = [...active, ...seriesItems, ...rest];
     if (this.status) this.status = { ...this.status, queue: newQueue };
     try {
-      for (let i = 0; i < seriesItems.length; i++) {
-        await reorderDownload(seriesItems[i].chapter.id, first + i);
-      }
+      const ops = seriesItems.map((item, i) => ({
+        chapterId: item.chapter.id,
+        to: first + i,
+        chapterName: item.chapter.name,
+      }));
+      await this.batchReorder(ops);
       await this.poll();
     } catch { await this.poll(); }
     finally { this.batchWorking = false; }
@@ -397,9 +491,12 @@ class DownloadStore {
     if (this.status) this.status = { ...this.status, queue: newQueue };
     const last = this.queue.length - 1;
     try {
-      for (let i = 0; i < seriesItems.length; i++) {
-        await reorderDownload(seriesItems[i].chapter.id, last - (seriesItems.length - 1 - i));
-      }
+      const ops = seriesItems.map((item, i) => ({
+        chapterId: item.chapter.id,
+        to: last - (seriesItems.length - 1 - i),
+        chapterName: item.chapter.name,
+      }));
+      await this.batchReorder(ops);
       await this.poll();
     } catch { await this.poll(); }
     finally { this.batchWorking = false; }
@@ -421,9 +518,12 @@ class DownloadStore {
     }
     if (this.status) this.status = { ...this.status, queue: newQueue };
     try {
-      for (let k = 0; k < seriesIndices.length; k++) {
-        await reorderDownload(reversedItems[k].chapter.id, seriesIndices[k]);
-      }
+      const ops = seriesIndices.map((si, k) => ({
+        chapterId: reversedItems[k].chapter.id,
+        to: si,
+        chapterName: reversedItems[k].chapter.name,
+      }));
+      await this.batchReorder(ops);
       await this.poll();
     } catch { await this.poll(); }
     finally { this.batchWorking = false; }

--- a/src/lib/types/api.ts
+++ b/src/lib/types/api.ts
@@ -7,7 +7,7 @@ export interface DownloadQueueItem {
     name: string
     mangaId: number
     pageCount: number
-    manga: { id: number; title: string; thumbnailUrl: string } | null
+    manga: { id: number; title: string; thumbnailUrl: string; sourceId?: string } | null
   }
 }
 

--- a/src/lib/types/settings.ts
+++ b/src/lib/types/settings.ts
@@ -119,6 +119,7 @@ export interface Settings {
   trackerSyncBack: boolean; trackerSyncBackThreshold: number | null; trackerRespectScanlatorFilter: boolean
   pinchZoom?: boolean; autoLinkOnOpen: boolean
   downloadToastsEnabled: boolean; downloadAutoRetry: boolean
+  warmingEnabled: boolean; warmingConcurrency: number; warmingChaptersMax: number; warmingColdBuffer: number
   hiddenLibraryTabs: string[]; libraryPinnedTabOrder: string[]
   autoScroll?: boolean; autoScrollSpeed?: number; disableAutoComplete: boolean
   systemThemeSync?: boolean; systemThemeDark?: string; systemThemeLight?: string
@@ -166,6 +167,7 @@ export const DEFAULT_SETTINGS: Settings = {
   trackerSyncBack: false, trackerSyncBackThreshold: 20, trackerRespectScanlatorFilter: true,
   pinchZoom: false, autoLinkOnOpen: false,
   downloadToastsEnabled: true, downloadAutoRetry: false,
+  warmingEnabled: true, warmingConcurrency: 8, warmingChaptersMax: 5, warmingColdBuffer: 2,
   hiddenLibraryTabs: [], libraryPinnedTabOrder: [],
   autoScroll: false, autoScrollSpeed: 5, disableAutoComplete: false,
   windowControls: true,


### PR DESCRIPTION

<img width="1486" height="776" alt="Screenshot 2026-08-28 124451" src="https://github.com/user-attachments/assets/d082de70-ec12-4faf-9714-03d3ccd409a0" />
<img width="790" height="653" alt="Screenshot 2026-08-28 124404" src="https://github.com/user-attachments/assets/61697d05-1cdc-4dba-8790-9f3c5be886ca" />
- Add page pre-cacher that fetches queued chapter pages in parallel so Suwayomi's sequential downloader skips already-cached pages (faster). Per-chapter round-robin pipeline, configurable settings on Storage tab, warmed-state persisted across pause/reload.
- Batch enqueue (enqueueMany) to stop trickle downloads and auto-start races.
- Pause-hold forceStop only on explicit pause; resume re-arms warming.
- Reliable queue clear/remove: timeout + retry + confirmation dialog, pause warming during mutations.
- Warm precache indicator (blue bar + bolt) persists through download, pause, reload.
- Bulk reorder now uses a lightweight mutation (returns state only) and shows a live progress toast with cancel; fixes 1-2s/chapter lag on series move buttons.