### PR TITLE
Feat: AniList library import

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,6 @@ vite.config.js.timestamp-*
 vite.config.ts.timestamp-*
 
 *.code-workspace
+
+# Local scratch, not for upstream
+TODO.md

--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,5 @@ Thumbs.db
 
 vite.config.js.timestamp-*
 vite.config.ts.timestamp-*
+
+*.code-workspace

--- a/src/app.css
+++ b/src/app.css
@@ -2,6 +2,7 @@
 @import '$lib/styles/themes.css';
 
 :root {
+  color-scheme: dark;
   --bg-void:      #080808;
   --bg-base:      #0c0c0c;
   --bg-surface:   #101010;

--- a/src/lib/components/extensions/panels/SourceMigrateModal.svelte
+++ b/src/lib/components/extensions/panels/SourceMigrateModal.svelte
@@ -53,6 +53,7 @@
   let targetSource: Source | null = $state(null);
   let selectedLang              = $state("all");
   let langStripEl: HTMLDivElement | undefined = $state();
+  let langStripOverflow = $state(false);
 
   let entries: EntryResult[]    = $state([]);
   let searchProgress            = $state({ done: 0, total: 0 });
@@ -65,6 +66,22 @@
     return langs;
   });
   const hasMultipleLangs = $derived(availableLangs.length > 1);
+
+  $effect(() => {
+    const el = langStripEl;
+    void availableLangs.length;
+    if (!el) {
+      langStripOverflow = false;
+      return;
+    }
+    const measure = () => {
+      langStripOverflow = el.scrollWidth > el.clientWidth + 1;
+    };
+    measure();
+    const ro = new ResizeObserver(measure);
+    ro.observe(el);
+    return () => ro.disconnect();
+  });
   const visibleSources   = $derived.by(() => {
     if (selectedLang !== "all") return allSources.filter(s => s.lang === selectedLang);
     const map = new Map<string, Source>();
@@ -202,7 +219,9 @@
         {:else}
           {#if hasMultipleLangs}
             <div class="src-lang-bar">
-              <button class="src-lang-nav" onclick={() => scrollLangStrip(-1)}>‹</button>
+              {#if langStripOverflow}
+                <button class="src-lang-nav" onclick={() => scrollLangStrip(-1)}>‹</button>
+              {/if}
               <div class="src-lang-chips" bind:this={langStripEl}>
                 <button class="src-lang-chip" class:src-lang-chip-active={selectedLang === "all"} onclick={() => selectedLang = "all"}>All</button>
                 {#each availableLangs as lang}
@@ -211,7 +230,9 @@
                   </button>
                 {/each}
               </div>
-              <button class="src-lang-nav" onclick={() => scrollLangStrip(1)}>›</button>
+              {#if langStripOverflow}
+                <button class="src-lang-nav" onclick={() => scrollLangStrip(1)}>›</button>
+              {/if}
             </div>
           {/if}
           <div class="source-list">

--- a/src/lib/components/settings/Settings.css
+++ b/src/lib/components/settings/Settings.css
@@ -232,6 +232,39 @@
   background: var(--bg-void);
 }
 
+.s-check {
+  appearance: none;
+  -webkit-appearance: none;
+  width: 14px;
+  height: 14px;
+  margin: 0;
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius-sm);
+  background: var(--bg-overlay);
+  cursor: pointer;
+  flex-shrink: 0;
+  display: grid;
+  place-items: center;
+  transition: background var(--t-base), border-color var(--t-base);
+}
+.s-check:checked {
+  background: var(--accent);
+  border-color: var(--accent);
+}
+.s-check:checked::after {
+  content: "";
+  width: 6px;
+  height: 3px;
+  margin-bottom: 2px;
+  border-left: 1.5px solid var(--bg-void);
+  border-bottom: 1.5px solid var(--bg-void);
+  transform: rotate(-45deg);
+}
+.s-check:disabled {
+  opacity: 0.4;
+  cursor: default;
+}
+
 
 .s-sync-pair {
   display: grid;

--- a/src/lib/components/settings/Settings.svelte
+++ b/src/lib/components/settings/Settings.svelte
@@ -6,6 +6,7 @@
   import { eventToKeybind } from '$lib/core/keybinds/keybindEngine'
   import type { Keybinds } from '$lib/core/keybinds/defaultBinds'
   import { selectPortal } from '$lib/core/ui/selectPortal'
+  import { trackerState } from '$lib/state/trackers.svelte'
 
   import GeneralSettings     from './sections/GeneralSettings.svelte'
   import AppearanceSettings  from './sections/AppearanceSettings.svelte'
@@ -24,6 +25,7 @@
   import ServerSettings      from './sections/ServerSettings.svelte'
   import ModalBlur           from '$lib/components/shared/ui/ModalBlur.svelte'
   import BugReporter         from './BugReporter.svelte'
+  import TrackerImportModal  from '$lib/components/tracking/TrackerImportModal.svelte'
 
   interface Props { onclose?: () => void; onOpenThemeEditor?: (id?: string | null) => void }
   let { onclose, onOpenThemeEditor }: Props = $props()
@@ -55,6 +57,7 @@
   let contentBodyEl: HTMLDivElement
   let modalEl: HTMLDivElement
   let bugReporterOpen    = $state(false)
+  let importKey          = $state<string | null>(null)
 
   $effect(() => { tab; tick().then(() => contentBodyEl?.scrollTo({ top: 0 })) })
 
@@ -78,7 +81,7 @@
   let listeningKey: keyof Keybinds | null = $state(null)
 
   $effect(() => {
-    const onKey = (e: KeyboardEvent) => { if (e.key === 'Escape' && !listeningKey && !bugReporterOpen) { e.stopPropagation(); close() } }
+    const onKey = (e: KeyboardEvent) => { if (e.key === 'Escape' && !listeningKey && !bugReporterOpen && !importKey) { e.stopPropagation(); close() } }
     window.addEventListener('keydown', onKey, true)
     return () => window.removeEventListener('keydown', onKey, true)
   })
@@ -195,7 +198,7 @@
         {:else if tab === 'automation'}
           <AutomationSettings />
         {:else if tab === 'tracking'}
-          <TrackingSettings />
+          <TrackingSettings bind:importKey />
         {:else if tab === 'performance'}
           <PerformanceSettings />
         {:else if tab === 'keybinds'}
@@ -221,6 +224,17 @@
 
 {#if bugReporterOpen}
   <BugReporter onClose={() => (bugReporterOpen = false)} />
+{/if}
+
+{#if importKey}
+  {@const t = trackerState.byKey(importKey)}
+  <TrackerImportModal
+    trackerKey={importKey}
+    trackerName={t?.name ?? "AniList"}
+    username={t?.username ?? null}
+    onClose={() => (importKey = null)}
+    onDone={() => (importKey = null)}
+  />
 {/if}
 
 <style>

--- a/src/lib/components/settings/sections/TrackingSettings.svelte
+++ b/src/lib/components/settings/sections/TrackingSettings.svelte
@@ -1,15 +1,17 @@
 <script lang="ts">
   import { onMount, onDestroy } from "svelte";
-  import { ArrowSquareOut, CheckCircle, CircleNotch, LinkBreak, ArrowClockwise, Copy } from "phosphor-svelte";
+  import { ArrowSquareOut, CheckCircle, CircleNotch, LinkBreak, ArrowClockwise, Copy, TrayArrowDown } from "phosphor-svelte";
   import { platformService } from "$lib/platform-service";
   import { addToast } from "$lib/state/notifications.svelte";
   import { trackerState } from "$lib/state/trackers.svelte";
   import { tsunagu } from "$lib/server-adapters/tsunagu";
   import TrackerLogo from "$lib/components/tracking/TrackerLogo.svelte";
+  import TrackerImportModal from "$lib/components/tracking/TrackerImportModal.svelte";
 
   let drafts  = $state<Record<string, string>>({});
   let busy    = $state<Record<string, boolean>>({});
   let polling = $state<Record<string, boolean>>({});
+  let importKey = $state<string | null>(null);
 
   let alive = true;
   onMount(() => { trackerState.load(); });
@@ -123,6 +125,11 @@
 
             {:else if t.isLoggedIn}
               <div class="trk-actions">
+                {#if t.key === "anilist"}
+                  <button class="s-btn s-btn-accent" onclick={() => (importKey = t.key)}>
+                    <TrayArrowDown size={12} weight="light" /> Import from {t.name}
+                  </button>
+                {/if}
                 <button class="s-btn s-btn-danger" disabled={busy[t.key]} onclick={() => disconnect(t.key)}>
                   <LinkBreak size={12} weight="light" /> Disconnect
                 </button>
@@ -168,6 +175,17 @@
   </div>
 </div>
 
+{#if importKey}
+  {@const t = trackerState.byKey(importKey)}
+  <TrackerImportModal
+    trackerKey={importKey}
+    trackerName={t?.name ?? "AniList"}
+    username={t?.username ?? null}
+    onClose={() => (importKey = null)}
+    onDone={() => (importKey = null)}
+  />
+{/if}
+
 <style>
   .trk-reload {
     display: flex; align-items: center; justify-content: center;
@@ -204,7 +222,7 @@
 
   .trk-connect { display: flex; flex-direction: column; gap: var(--sp-2); }
   .trk-row     { display: flex; align-items: center; gap: var(--sp-2); }
-  .trk-actions { display: flex; }
+  .trk-actions { display: flex; gap: var(--sp-2); }
   .trk-icon-btn { padding: 5px 10px; }
 
   .s-desc code {

--- a/src/lib/components/settings/sections/TrackingSettings.svelte
+++ b/src/lib/components/settings/sections/TrackingSettings.svelte
@@ -6,12 +6,13 @@
   import { trackerState } from "$lib/state/trackers.svelte";
   import { tsunagu } from "$lib/server-adapters/tsunagu";
   import TrackerLogo from "$lib/components/tracking/TrackerLogo.svelte";
-  import TrackerImportModal from "$lib/components/tracking/TrackerImportModal.svelte";
+
+  interface Props { importKey?: string | null }
+  let { importKey = $bindable(null) }: Props = $props();
 
   let drafts  = $state<Record<string, string>>({});
   let busy    = $state<Record<string, boolean>>({});
   let polling = $state<Record<string, boolean>>({});
-  let importKey = $state<string | null>(null);
 
   let alive = true;
   onMount(() => { trackerState.load(); });
@@ -174,17 +175,6 @@
     </div>
   </div>
 </div>
-
-{#if importKey}
-  {@const t = trackerState.byKey(importKey)}
-  <TrackerImportModal
-    trackerKey={importKey}
-    trackerName={t?.name ?? "AniList"}
-    username={t?.username ?? null}
-    onClose={() => (importKey = null)}
-    onDone={() => (importKey = null)}
-  />
-{/if}
 
 <style>
   .trk-reload {

--- a/src/lib/components/shared/manga/MigrateModal.svelte
+++ b/src/lib/components/shared/manga/MigrateModal.svelte
@@ -54,6 +54,7 @@
   let selectedExtension: Extension | null = $state(null);
   let selectedLang                    = $state("all");
   let langStripEl: HTMLDivElement | undefined = $state();
+  let langStripOverflow = $state(false);
 
   const stepIdx        = $derived(STEPS.indexOf(step));
   const availableLangs = $derived.by(() => {
@@ -63,6 +64,22 @@
     return langs;
   });
   const hasMultipleLangs = $derived(availableLangs.length > 1);
+
+  $effect(() => {
+    const el = langStripEl;
+    void availableLangs.length;
+    if (!el) {
+      langStripOverflow = false;
+      return;
+    }
+    const measure = () => {
+      langStripOverflow = el.scrollWidth > el.clientWidth + 1;
+    };
+    measure();
+    const ro = new ResizeObserver(measure);
+    ro.observe(el);
+    return () => ro.disconnect();
+  });
   const visibleExtensions = $derived.by(() => {
     if (selectedLang !== "all") return extensions.filter(e => e.lang === selectedLang);
     const map = new Map<string, Extension>();
@@ -235,7 +252,9 @@
         {:else}
           {#if hasMultipleLangs}
             <div class="src-lang-bar">
-              <button class="src-lang-nav" onclick={() => scrollLangStrip(-1)}>‹</button>
+              {#if langStripOverflow}
+                <button class="src-lang-nav" onclick={() => scrollLangStrip(-1)}>‹</button>
+              {/if}
               <div class="src-lang-chips" bind:this={langStripEl}>
                 <button class="src-lang-chip" class:src-lang-chip-active={selectedLang === "all"} onclick={() => selectedLang = "all"}>All</button>
                 {#each availableLangs as lang}
@@ -244,7 +263,9 @@
                   </button>
                 {/each}
               </div>
-              <button class="src-lang-nav" onclick={() => scrollLangStrip(1)}>›</button>
+              {#if langStripOverflow}
+                <button class="src-lang-nav" onclick={() => scrollLangStrip(1)}>›</button>
+              {/if}
             </div>
           {/if}
           <div class="source-list">

--- a/src/lib/components/tracking/TrackerImportModal.svelte
+++ b/src/lib/components/tracking/TrackerImportModal.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { X, CircleNotch, ArrowRight, Check, Warning, Sparkle, DownloadSimple, TrayArrowDown, ArrowsClockwise, Pause, Play, Trash } from "phosphor-svelte";
+  import { X, CircleNotch, ArrowRight, Check, Warning, Sparkle, DownloadSimple, TrayArrowDown, ArrowsClockwise, Pause, Play, Trash, Books } from "phosphor-svelte";
   import { tsunagu } from "$lib/server-adapters/tsunagu";
   import Thumbnail from "$lib/components/shared/manga/Thumbnail.svelte";
   import ExtensionIcon from "$lib/components/extensions/ExtensionIcon.svelte";
@@ -24,6 +24,7 @@
   const SEARCH_GAP_MS = 2000;
   const SEARCH_QUERY_GAP_MS = 500;
   const ANILIST_GAP_MS = 1200;
+  const SNAPSHOT_TTL_MS = 15 * 60 * 1000;
   const MATCH_THRESHOLD = 0.3;
   const GOOD_ENOUGH = 0.55;
 
@@ -149,6 +150,7 @@
   let langStripEl: HTMLDivElement | undefined = $state();
   let selectedStatuses = $state<string[]>(["CURRENT"]);
   let dryRun = $state(false);
+  let stubImport = $state(false);
   let cancelled = false;
   let halt = false;
   let massSourceId = $state("");
@@ -157,6 +159,8 @@
   let ledger: ImportLedger = $state({ ...EMPTY_LEDGER });
   let listSnapshot: TrackerLibraryEntry[] = $state([]);
   let snapshotLoading = $state(false);
+  let snapshotAt = 0;
+  let snapshotTask: Promise<void> | null = null;
   let pulledIds: string[] = $state([]);
 
   let entries: EntryResult[] = $state([]);
@@ -350,21 +354,53 @@
     return new Set(Object.values(ledger.lastSeen).flat());
   }
 
+  function snapshotIsFresh(): boolean {
+    return snapshotAt > 0 && Date.now() - snapshotAt < SNAPSHOT_TTL_MS;
+  }
+
+  function snapshotForStatuses(statuses: string[]): TrackerLibraryEntry[] {
+    const wanted = new Set(statuses.map(s => s.toUpperCase()));
+    return listSnapshot.filter(e => wanted.has((e.status || "").toUpperCase()));
+  }
+
+  function mergeSnapshot(rows: TrackerLibraryEntry[]) {
+    const byId = new Map(listSnapshot.map(e => [e.remoteId, e]));
+    for (const r of rows) byId.set(r.remoteId, r);
+    listSnapshot = [...byId.values()];
+    snapshotAt = Date.now();
+  }
+
   async function refreshSnapshot() {
     snapshotLoading = true;
-    try {
-      const [remote, local] = await Promise.all([
-        tsunagu.trackerLibrary(trackerKey, "MANGA" as ContentType, STATUSES.map(s => s.key)),
-        tsunagu.library("MANGA").catch(() => []),
-      ]);
-      if (cancelled) return;
-      listSnapshot = remote;
-      pulledIds = local.flatMap(m => (m.trackLinks ?? []).filter(l => l.trackerKey === trackerKey).map(l => l.remoteId));
-    } catch {
-      listSnapshot = [];
-    } finally {
-      snapshotLoading = false;
-    }
+    const run = (async () => {
+      try {
+        const [remote, local] = await Promise.all([
+          tsunagu.trackerLibrary(trackerKey, "MANGA" as ContentType, STATUSES.map(s => s.key)),
+          tsunagu.library("MANGA").catch(() => []),
+        ]);
+        if (cancelled) return;
+        listSnapshot = remote;
+        snapshotAt = Date.now();
+        pulledIds = local.flatMap(m => (m.trackLinks ?? []).filter(l => l.trackerKey === trackerKey).map(l => l.remoteId));
+      } catch {
+        listSnapshot = [];
+        snapshotAt = 0;
+      } finally {
+        snapshotLoading = false;
+      }
+    })();
+    snapshotTask = run;
+    await run;
+  }
+
+  async function loadRemoteList(): Promise<{ rows: TrackerLibraryEntry[]; fromCache: boolean }> {
+    if (snapshotTask) await snapshotTask;
+    if (cancelled) return { rows: [], fromCache: true };
+    if (snapshotIsFresh()) return { rows: snapshotForStatuses(selectedStatuses), fromCache: true };
+    const remote = await tsunagu.trackerLibrary(trackerKey, "MANGA" as ContentType, selectedStatuses);
+    if (cancelled) return { rows: remote, fromCache: false };
+    mergeSnapshot(remote);
+    return { rows: remote, fromCache: false };
   }
 
   function readCache(): CachePayload | null {
@@ -398,6 +434,7 @@
 
   function draftSourceName(): string {
     if (!draft) return "";
+    if (!draft.sourceId) return "Library only";
     return allSources.find(s => s.id === draft!.sourceId)?.displayName ?? "source";
   }
 
@@ -502,6 +539,7 @@
 
   async function startSearch(target: Source) {
     halt = false;
+    stubImport = false;
     targetSource = target;
     massSourceId = target.id;
     selectedIds = [];
@@ -510,8 +548,11 @@
     searchProgress = { done: 0, total: 0 };
 
     let remote: TrackerLibraryEntry[];
+    let fromCache = false;
     try {
-      remote = await tsunagu.trackerLibrary(trackerKey, "MANGA" as ContentType, selectedStatuses);
+      const loaded = await loadRemoteList();
+      remote = loaded.rows;
+      fromCache = loaded.fromCache;
     } catch (e: any) {
       phase = "pick-target";
       addToast({ kind: "error", title: "Couldn't fetch AniList list", body: e?.message ?? String(e) });
@@ -543,22 +584,80 @@
       return 0;
     });
     searchProgress = { done: 0, total: entries.length };
-    rememberSeen(remote, selectedStatuses);
+    if (!fromCache) rememberSeen(remote, selectedStatuses);
     persistCache();
     await continueMatching();
+  }
+
+  async function startStubImport() {
+    halt = false;
+    stubImport = true;
+    targetSource = null;
+    massSourceId = "";
+    selectedIds = [];
+    phase = "matching";
+    entries = [];
+    searchProgress = { done: 0, total: 0 };
+
+    let remote: TrackerLibraryEntry[];
+    let fromCache = false;
+    try {
+      const loaded = await loadRemoteList();
+      remote = loaded.rows;
+      fromCache = loaded.fromCache;
+    } catch (e: any) {
+      phase = "pick-target";
+      addToast({ kind: "error", title: "Couldn't fetch AniList list", body: e?.message ?? String(e) });
+      return;
+    }
+    if (cancelled || halt) return;
+
+    const local = await tsunagu.library("MANGA").catch(() => []);
+    const alreadyByRemote = new Set(
+      local.flatMap(m => (m.trackLinks ?? []).filter(l => l.trackerKey === trackerKey).map(l => l.remoteId)),
+    );
+    pulledIds = [...alreadyByRemote];
+    const seen = previouslySeenIds();
+    const hasHistory = ledger.lastFetchedAt > 0;
+
+    entries = remote.map(r => ({
+      remote: r,
+      match: null,
+      similarity: 1,
+      status: alreadyByRemote.has(r.remoteId) ? "already" : "found",
+      sourceId: null,
+      fresh: hasHistory && !seen.has(r.remoteId) && !alreadyByRemote.has(r.remoteId),
+    }));
+    entries.sort((a, b) => {
+      if (a.status === "already" && b.status !== "already") return 1;
+      if (b.status === "already" && a.status !== "already") return -1;
+      if (a.fresh && !b.fresh) return -1;
+      if (b.fresh && !a.fresh) return 1;
+      return 0;
+    });
+    searchProgress = { done: entries.length, total: entries.length };
+    if (!fromCache) rememberSeen(remote, selectedStatuses);
+    persistCache();
+    if (cancelled || halt) return;
+    if (entries.every(e => e.status === "already")) {
+      phase = "done";
+      return;
+    }
+    phase = "assign";
   }
 
   async function resumeFromDraft() {
     if (!draft) return;
     halt = false;
     cancelled = false;
+    stubImport = !draft.sourceId;
     applyCache(draft);
     selectedIds = [];
-    if (!targetSource) {
+    if (!stubImport && !targetSource) {
       addToast({ kind: "error", title: "Source no longer installed" });
       return;
     }
-    if (pendingCount > 0) {
+    if (!stubImport && pendingCount > 0) {
       await continueMatching();
       return;
     }
@@ -656,17 +755,22 @@
   }
 
   async function importOne(entry: EntryResult) {
+    if (!entry.sourceId) {
+      await tsunagu.createTrackerStub(
+        trackerKey,
+        entry.remote.remoteId,
+        "MANGA",
+        displayTitle(entry.remote),
+        entry.remote.coverUrl,
+      );
+      if (!pulledIds.includes(entry.remote.remoteId)) pulledIds = [...pulledIds, entry.remote.remoteId];
+      return;
+    }
     const src = sourceById(entry.sourceId);
     if (!src) throw new Error("No source for this title");
     if (!entry.match?.sourceEntryId) throw new Error("No match for this title");
     const info = await tsunagu.mangaInfo(src.id, entry.match.sourceEntryId, true);
     if (!info.inLibrary) await tsunagu.setInLibrary(info.id, true);
-    if (trackerKey === "anilist") {
-      try {
-        await tsunagu.applyMetadataMatch(info.id, entry.remote.remoteId, "anilist");
-      } catch { /* metadata is optional; tracking still binds */ }
-      await sleep(ANILIST_GAP_MS);
-    }
     const link = await tsunagu.bindTrack(info.id, trackerKey, entry.remote.remoteId);
     await sleep(ANILIST_GAP_MS);
     await tsunagu.updateTrack(link.id, {
@@ -681,7 +785,7 @@
     const idx = entries.findIndex(e => e.remote.remoteId === remoteId);
     if (idx < 0 || retryingIds.includes(remoteId)) return;
     const entry = entries[idx];
-    if (!entry.match) {
+    if (entry.sourceId && !entry.match) {
       const src = sourceById(entry.sourceId);
       if (src) await searchRow(remoteId, src.id);
       return;
@@ -696,7 +800,6 @@
         await importOne(entry);
         entries[idx] = { ...entries[idx], status: "imported", error: undefined };
         await loadLibrary(true);
-        void refreshSnapshot();
       }
       persistCache();
     } catch (e: unknown) {
@@ -708,7 +811,7 @@
   }
 
   async function startImport() {
-    const toImport = entries.filter(e => e.status === "found" && e.match);
+    const toImport = entries.filter(e => e.status === "found" && (e.match || !e.sourceId));
     if (toImport.length === 0) {
       phase = (noMatchCount > 0 || pendingCount > 0 || failedCount > 0) ? "assign" : "done";
       return;
@@ -739,7 +842,6 @@
 
     if (!dryRun) {
       await loadLibrary(true);
-      void refreshSnapshot();
     }
 
     if (halt) {
@@ -753,7 +855,7 @@
       phase = "assign";
       addToast({
         kind: "success",
-        title: dryRun ? "Dry run complete" : "Imported matched titles",
+        title: dryRun ? "Dry run complete" : stubImport ? "Imported library stubs" : "Imported matched titles",
         body: `${importProgress.done - importProgress.failed} imported, ${noMatchCount + pendingCount} still unmatched`,
       });
       return;
@@ -803,7 +905,7 @@
         <div class="source-context-info">
           <span class="modal-eyebrow">Library import</span>
           <span class="modal-title">Import from {trackerName}</span>
-          <span class="modal-sub">Manga only · match titles on one source, then assign the rest</span>
+          <span class="modal-sub">Manga only · library without a source, or match titles on one source</span>
         </div>
       </div>
       {#if phase !== "importing"}
@@ -858,16 +960,32 @@
         {/if}
         <p class="rate-note">
           <Warning size={12} weight="bold" />
-          AniList and sources rate-limit bulk imports. Wait a few minutes between runs. Skip MangaDex for a full list.
+          AniList rate-limits bulk imports. Matching on a source is slower. Skip MangaDex for a full list.
         </p>
 
         <div class="phase-label-row">
-          <span class="phase-label">Default destination source</span>
+          <span class="phase-label">Import into library</span>
+        </div>
+        <div class="source-list source-list-tight">
+          <button class="source-row source-row-library" onclick={() => void startStubImport()}>
+            <div class="source-icon-wrap logo">
+              <Books size={18} weight="light" />
+            </div>
+            <div class="source-info">
+              <span class="source-name">Library only · no source</span>
+              <span class="source-meta">Titles and AniList tracking. Assign a source later.</span>
+            </div>
+            <ArrowRight size={13} weight="light" class="source-arrow" />
+          </button>
+        </div>
+
+        <div class="phase-label-row">
+          <span class="phase-label">Or match on a source</span>
         </div>
         {#if loadingSources}
           <div class="centered"><CircleNotch size={16} weight="light" class="anim-spin" style="color:var(--text-faint)" /></div>
         {:else if allSources.length === 0}
-          <div class="centered"><span class="hint">Install a manga source first.</span></div>
+          <div class="centered"><span class="hint">Install a manga source to match covers and chapters.</span></div>
         {:else}
           {#if hasMultipleLangs}
             <div class="src-lang-bar">
@@ -913,6 +1031,13 @@
                   <ExtensionIcon src={targetSource.iconUrl} alt={targetSource.name} class="source-icon" size={20} />
                 </div>
                 <span class="review-source-name">{targetSource.displayName}</span>
+              </div>
+            {:else if stubImport}
+              <div class="review-source">
+                <div class="source-icon-wrap small logo">
+                  <Books size={12} weight="light" />
+                </div>
+                <span class="review-source-name">Library only</span>
               </div>
             {/if}
           </div>
@@ -967,6 +1092,8 @@
                     <span class="entry-sim">{Math.round(entry.similarity * 100)}%</span>
                     <span class="entry-prog">ch. {entry.remote.progress}</span>
                   </span>
+                {:else if entry.status === "found"}
+                  <span class="entry-match">Library stub · ch. {entry.remote.progress}</span>
                 {:else if entry.status === "no-match"}
                   <span class="entry-no-match">No match found</span>
                 {:else if entry.status === "already"}
@@ -1011,7 +1138,7 @@
             {#if (foundCount > 0 || missingEntries.length > 0) && alreadyCount > 0}<span class="stat-dot">·</span>{/if}
             {#if alreadyCount > 0}<span class="stat-already">{alreadyCount} already in library</span>{/if}
           </span>
-          {#if assignSources.length > 0}
+          {#if assignSources.length > 0 && !stubImport}
             <label class="assign-default">
               Default
               <select
@@ -1028,6 +1155,7 @@
           {/if}
         </div>
 
+        {#if !stubImport}
         <div class="mass-bar">
           <label class="mass-check">
             <input class="s-check" type="checkbox" checked={allMissingSelected} onchange={toggleAllMissing} />
@@ -1042,6 +1170,7 @@
             Search {selectedMissing}
           </button>
         </div>
+        {/if}
 
         <div class="table-wrap">
           <table class="assign-table">
@@ -1050,8 +1179,8 @@
                 <th class="col-check"></th>
                 <th class="col-title">Title</th>
                 <th class="col-prog">Ch.</th>
-                <th class="col-src">Source</th>
-                <th class="col-stat">Match</th>
+                {#if !stubImport}<th class="col-src">Source</th>{/if}
+                <th class="col-stat">{stubImport ? "Status" : "Match"}</th>
               </tr>
             </thead>
             <tbody>
@@ -1087,6 +1216,7 @@
                       </div>
                     </td>
                     <td class="col-prog">{entry.remote.progress}</td>
+                    {#if !stubImport}
                     <td class="col-src">
                       {#if entry.status === "imported"}
                         {@const src = sourceById(entry.sourceId)}
@@ -1104,6 +1234,7 @@
                         </select>
                       {/if}
                     </td>
+                    {/if}
                     <td class="col-stat">
                       <div class="stat-cell">
                         {#if entry.status === "searching" || retryingIds.includes(entry.remote.remoteId)}
@@ -1112,7 +1243,12 @@
                           <span class="entry-searching">Not searched</span>
                         {:else if entry.status === "found"}
                           <Check size={13} weight="bold" style="color:var(--color-success)" />
-                          <span class="entry-done">Matched</span>
+                          <span class="entry-done">{stubImport ? "Ready" : "Matched"}</span>
+                          {#if stubImport}
+                            <button class="entry-exclude-btn" onclick={() => excludeEntry(idx)} title="Skip this title">
+                              <X size={10} weight="bold" />
+                            </button>
+                          {/if}
                         {:else if entry.status === "imported"}
                           <Check size={13} weight="bold" style="color:var(--color-success)" />
                           <span class="entry-done">Imported</span>
@@ -1151,14 +1287,14 @@
               onclick={() => (dryRun = !dryRun)}
             ><span class="s-toggle-thumb"></span></button>
           </div>
-          {#if pendingCount > 0}
+          {#if pendingCount > 0 && !stubImport}
             <button class="back-btn" onclick={() => void continueMatching()}>
               <Play size={12} weight="bold" /> Resume search
             </button>
           {/if}
           <button class="migrate-btn" onclick={() => void startImport()} disabled={foundCount === 0}>
             <TrayArrowDown size={13} weight="bold" />
-            Import {foundCount} matched
+            Import {foundCount}{stubImport ? "" : " matched"}
           </button>
         </div>
 
@@ -1239,8 +1375,10 @@
   .src-lang-chip-active { color: var(--accent-fg); border-color: var(--accent-dim); background: var(--accent-muted); }
 
   .source-list { flex: 1; overflow-y: auto; padding: var(--sp-2); display: flex; flex-direction: column; gap: 1px; }
+  .source-list-tight { flex: 0 0 auto; padding-bottom: 0; }
   .source-row { display: flex; align-items: center; gap: var(--sp-3); padding: 8px var(--sp-3); border-radius: var(--radius-md); border: 1px solid transparent; background: none; text-align: left; width: 100%; cursor: pointer; transition: background var(--t-fast), border-color var(--t-fast); }
   .source-row:hover { background: var(--bg-raised); border-color: var(--border-dim); }
+  .source-row-library { border-color: var(--border-dim); }
   .source-info { flex: 1; display: flex; flex-direction: column; gap: 2px; overflow: hidden; }
   .source-name { font-size: var(--text-sm); font-weight: var(--weight-medium); color: var(--text-secondary); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
   .source-meta { font-family: var(--font-ui); font-size: var(--text-2xs); color: var(--text-faint); letter-spacing: var(--tracking-wide); }

--- a/src/lib/components/tracking/TrackerImportModal.svelte
+++ b/src/lib/components/tracking/TrackerImportModal.svelte
@@ -1,0 +1,1327 @@
+<script lang="ts">
+  import { X, CircleNotch, ArrowRight, Check, Warning, Sparkle, DownloadSimple, TrayArrowDown, ArrowsClockwise, Pause, Play, Trash } from "phosphor-svelte";
+  import { tsunagu } from "$lib/server-adapters/tsunagu";
+  import Thumbnail from "$lib/components/shared/manga/Thumbnail.svelte";
+  import ExtensionIcon from "$lib/components/extensions/ExtensionIcon.svelte";
+  import TrackerLogo from "$lib/components/tracking/TrackerLogo.svelte";
+  import { addToast } from "$lib/state/notifications.svelte";
+  import { settingsState } from "$lib/state/settings.svelte";
+  import { loadLibrary } from "$lib/state/library.svelte";
+  import type { Manga, Source } from "$lib/types";
+  import type { ContentType, TrackerLibraryEntry } from "$lib/server-adapters/types";
+  import { toBrowseManga, toSource } from "$lib/components/browse/lib/searchFilter";
+  import { sourceErrorLabel } from "$lib/core/sourceErrors";
+
+  interface Props {
+    trackerKey: string;
+    trackerName: string;
+    username?: string | null;
+    onClose: () => void;
+    onDone: () => void;
+  }
+  let { trackerKey, trackerName, username = null, onClose, onDone }: Props = $props();
+
+  const SEARCH_GAP_MS = 1000;
+  const MATCH_THRESHOLD = 0.3;
+  const GOOD_ENOUGH = 0.55;
+
+  const STATUSES = [
+    { key: "CURRENT", label: "Reading" },
+    { key: "PLANNING", label: "Planning" },
+    { key: "COMPLETED", label: "Completed" },
+    { key: "PAUSED", label: "On hold" },
+    { key: "DROPPED", label: "Dropped" },
+    { key: "REPEATING", label: "Rereading" },
+  ] as const;
+
+  type Phase = "pick-target" | "matching" | "assign" | "importing" | "done";
+  type EntryStatus = "pending" | "searching" | "found" | "no-match" | "already" | "skipped" | "imported" | "failed";
+
+  interface EntryResult {
+    remote: TrackerLibraryEntry;
+    match: Manga | null;
+    similarity: number;
+    status: EntryStatus;
+    sourceId: string | null;
+    error?: string;
+    fresh?: boolean;
+  }
+
+  interface CachedMatch {
+    title: string;
+    thumbnailUrl: string;
+    sourceEntryId: string;
+    extensionId: string;
+    inLibrary: boolean;
+  }
+
+  interface CachePayload {
+    v: number;
+    trackerKey: string;
+    sourceId: string;
+    statuses: string[];
+    entries: Array<{
+      remote: TrackerLibraryEntry;
+      match: CachedMatch | null;
+      similarity: number;
+      status: EntryStatus;
+      sourceId: string | null;
+      error?: string;
+    }>;
+    searchDone: number;
+    searchTotal: number;
+  }
+
+  interface ImportLedger {
+    v: number;
+    lastStatuses: string[];
+    lastSeen: Record<string, string[]>;
+    lastFetchedAt: number;
+  }
+
+  const CACHE_VER = 1;
+  const LEDGER_VER = 1;
+
+  const EMPTY_LEDGER: ImportLedger = { v: LEDGER_VER, lastStatuses: ["CURRENT"], lastSeen: {}, lastFetchedAt: 0 };
+
+  function titleSimilarity(a: string, b: string): number {
+    const norm = (s: string) =>
+      s.toLowerCase().replace(/[^a-z0-9\s]/g, "").split(/\s+/).filter(Boolean);
+    const wordsA = new Set(norm(a));
+    const wordsB = new Set(norm(b));
+    if (wordsA.size === 0 || wordsB.size === 0) return 0;
+    const intersection = [...wordsA].filter(w => wordsB.has(w)).length;
+    return intersection / new Set([...wordsA, ...wordsB]).size;
+  }
+
+  function alStatusToTrack(s: string): number {
+    switch (s) {
+      case "CURRENT": return 1;
+      case "PLANNING": return 2;
+      case "COMPLETED": return 3;
+      case "PAUSED": return 4;
+      case "DROPPED": return 5;
+      case "REPEATING": return 6;
+      default: return 2;
+    }
+  }
+
+  function sleep(ms: number) {
+    return new Promise<void>((resolve) => setTimeout(resolve, ms));
+  }
+
+  function searchQueries(remote: TrackerLibraryEntry): string[] {
+    const out: string[] = [];
+    for (const t of [remote.titleEnglish, remote.titleRomaji, remote.title]) {
+      const s = (t ?? "").trim();
+      if (s && !out.includes(s)) out.push(s);
+    }
+    return out;
+  }
+
+  function displayTitle(remote: TrackerLibraryEntry): string {
+    return (remote.titleEnglish || remote.title || remote.titleRomaji || "Untitled").trim();
+  }
+
+  function displaySub(remote: TrackerLibraryEntry): string | null {
+    const primary = displayTitle(remote);
+    const romaji = (remote.titleRomaji ?? "").trim();
+    if (romaji && romaji !== primary) return romaji;
+    return null;
+  }
+
+  function scoreHit(remote: TrackerLibraryEntry, resultTitle: string): number {
+    let best = 0;
+    for (const q of searchQueries(remote)) {
+      const s = titleSimilarity(q, resultTitle);
+      if (s > best) best = s;
+    }
+    return best;
+  }
+
+  let phase: Phase = $state("pick-target");
+  let allSources: Source[] = $state([]);
+  let loadingSources = $state(true);
+  let targetSource: Source | null = $state(null);
+  let selectedLang = $state("all");
+  let langStripEl: HTMLDivElement | undefined = $state();
+  let selectedStatuses = $state<string[]>(["CURRENT"]);
+  let dryRun = $state(false);
+  let cancelled = false;
+  let halt = false;
+  let massSourceId = $state("");
+  let selectedIds = $state<string[]>([]);
+  let draft: CachePayload | null = $state(null);
+  let ledger: ImportLedger = $state({ ...EMPTY_LEDGER });
+  let listSnapshot: TrackerLibraryEntry[] = $state([]);
+  let snapshotLoading = $state(false);
+  let pulledIds: string[] = $state([]);
+
+  let entries: EntryResult[] = $state([]);
+  let searchProgress = $state({ done: 0, total: 0 });
+  let importProgress = $state({ done: 0, total: 0, failed: 0 });
+  let retryingIds = $state<string[]>([]);
+
+  const availableLangs = $derived.by(() => {
+    const langs = Array.from(new Set<string>(allSources.map(s => s.lang))).sort();
+    const en = langs.indexOf("en");
+    if (en > 0) { langs.splice(en, 1); langs.unshift("en"); }
+    return langs;
+  });
+  const hasMultipleLangs = $derived(availableLangs.length > 1);
+  const visibleSources = $derived.by(() => {
+    if (selectedLang !== "all") return allSources.filter(s => s.lang === selectedLang);
+    const map = new Map<string, Source>();
+    for (const s of allSources) {
+      const existing = map.get(s.name);
+      if (!existing || s.lang < existing.lang) map.set(s.name, s);
+    }
+    return Array.from(map.values());
+  });
+  const assignSources = $derived.by(() => {
+    const pref = settingsState.settings.preferredExtensionLang ?? "";
+    return [...allSources].sort((a, b) => {
+      if (pref) {
+        if (a.lang === pref && b.lang !== pref) return -1;
+        if (b.lang === pref && a.lang !== pref) return 1;
+      }
+      return a.displayName.localeCompare(b.displayName);
+    });
+  });
+
+  const foundCount = $derived(entries.filter(e => e.status === "found").length);
+  const noMatchCount = $derived(entries.filter(e => e.status === "no-match").length);
+  const alreadyCount = $derived(entries.filter(e => e.status === "already").length);
+  const importedCount = $derived(entries.filter(e => e.status === "imported").length);
+  const failedCount = $derived(entries.filter(e => e.status === "failed").length);
+  const skippedCount = $derived(entries.filter(e => e.status === "skipped").length);
+  const missingEntries = $derived(entries.filter(e => e.status === "no-match" || e.status === "searching" || e.status === "pending"));
+  const missingIds = $derived(missingEntries.map(e => e.remote.remoteId));
+  const pendingCount = $derived(entries.filter(e => e.status === "pending").length);
+  const pulledSet = $derived(new Set(pulledIds));
+  const statusCounts = $derived.by(() => {
+    const prevAll = new Set(Object.values(ledger.lastSeen).flat());
+    const hasHistory = ledger.lastFetchedAt > 0;
+    const out: Record<string, { left: number; neu: number; total: number }> = {};
+    for (const s of STATUSES) {
+      const rows = listSnapshot.filter(e => (e.status || "").toUpperCase() === s.key);
+      const left = rows.filter(e => !pulledSet.has(e.remoteId)).length;
+      const neu = hasHistory ? rows.filter(e => !prevAll.has(e.remoteId) && !pulledSet.has(e.remoteId)).length : 0;
+      out[s.key] = { left, neu, total: rows.length };
+    }
+    return out;
+  });
+  const leftoverTotal = $derived(STATUSES.reduce((n, s) => n + (statusCounts[s.key]?.left ?? 0), 0));
+  const newTotal = $derived(STATUSES.reduce((n, s) => n + (statusCounts[s.key]?.neu ?? 0), 0));
+  const allMissingSelected = $derived(missingIds.length > 0 && missingIds.every(id => selectedIds.includes(id)));
+  const selectedMissing = $derived(selectedIds.filter(id => missingIds.includes(id)).length);
+  const assignRows = $derived.by(() => {
+    const rank = (s: EntryStatus) => {
+      if (s === "searching") return 0;
+      if (s === "failed") return 1;
+      if (s === "pending") return 2;
+      if (s === "no-match") return 3;
+      if (s === "found") return 4;
+      if (s === "imported") return 5;
+      if (s === "skipped") return 6;
+      return 7;
+    };
+    return entries
+      .map((e, idx) => ({ e, idx }))
+      .filter(x => x.e.status !== "already")
+      .sort((a, b) => rank(a.e.status) - rank(b.e.status));
+  });
+
+  function sourceById(id: string | null): Source | null {
+    if (!id) return targetSource;
+    return allSources.find(s => s.id === id) ?? targetSource;
+  }
+
+  function sourceLabel(src: Source): string {
+    return `${src.displayName} (${src.lang.toUpperCase()})`;
+  }
+
+  function cacheKey() {
+    return `moku:tracker-import:${trackerKey}`;
+  }
+
+  function ledgerKey() {
+    return `moku:tracker-import-ledger:${trackerKey}`;
+  }
+
+  function toCachedMatch(m: Manga | null): CachedMatch | null {
+    if (!m?.sourceEntryId) return null;
+    return {
+      title: m.title,
+      thumbnailUrl: m.thumbnailUrl,
+      sourceEntryId: m.sourceEntryId,
+      extensionId: m.extensionId ?? "",
+      inLibrary: m.inLibrary,
+    };
+  }
+
+  function fromCachedMatch(m: CachedMatch | null): Manga | null {
+    if (!m) return null;
+    return {
+      id: `${m.extensionId}-${m.sourceEntryId}`,
+      title: m.title,
+      thumbnailUrl: m.thumbnailUrl,
+      inLibrary: m.inLibrary,
+      sourceEntryId: m.sourceEntryId,
+      extensionId: m.extensionId,
+      sourceId: m.extensionId,
+    };
+  }
+
+  function persistCache() {
+    if (typeof localStorage === "undefined") return;
+    if (entries.length === 0) return;
+    const leftover = entries.some(e =>
+      e.status === "pending" || e.status === "searching" || e.status === "no-match" || e.status === "found",
+    );
+    if (!leftover) {
+      clearCache();
+      return;
+    }
+    const payload: CachePayload = {
+      v: CACHE_VER,
+      trackerKey,
+      sourceId: targetSource?.id ?? "",
+      statuses: [...selectedStatuses],
+      entries: entries.map(e => ({
+        remote: e.remote,
+        match: toCachedMatch(e.match),
+        similarity: e.similarity,
+        status: e.status === "searching" ? "pending" : e.status,
+        sourceId: e.sourceId,
+        error: e.error,
+      })),
+      searchDone: searchProgress.done,
+      searchTotal: searchProgress.total,
+    };
+    try {
+      localStorage.setItem(cacheKey(), JSON.stringify(payload));
+      draft = payload;
+    } catch { /* quota */ }
+  }
+
+  function clearCache() {
+    try { localStorage.removeItem(cacheKey()); } catch { /* ignore */ }
+    draft = null;
+  }
+
+  function readLedger(): ImportLedger {
+    if (typeof localStorage === "undefined") return { ...EMPTY_LEDGER };
+    try {
+      const raw = localStorage.getItem(ledgerKey());
+      if (!raw) return { ...EMPTY_LEDGER };
+      const p = JSON.parse(raw) as ImportLedger;
+      if (p.v !== LEDGER_VER) return { ...EMPTY_LEDGER };
+      return {
+        v: LEDGER_VER,
+        lastStatuses: Array.isArray(p.lastStatuses) && p.lastStatuses.length ? p.lastStatuses : ["CURRENT"],
+        lastSeen: p.lastSeen && typeof p.lastSeen === "object" ? p.lastSeen : {},
+        lastFetchedAt: typeof p.lastFetchedAt === "number" ? p.lastFetchedAt : 0,
+      };
+    } catch {
+      return { ...EMPTY_LEDGER };
+    }
+  }
+
+  function persistLedger(patch: Partial<ImportLedger>) {
+    ledger = { ...ledger, ...patch, v: LEDGER_VER };
+    if (typeof localStorage === "undefined") return;
+    try {
+      localStorage.setItem(ledgerKey(), JSON.stringify(ledger));
+    } catch { /* quota */ }
+  }
+
+  function rememberSeen(rows: TrackerLibraryEntry[], statuses: string[]) {
+    const lastSeen = { ...ledger.lastSeen };
+    for (const key of statuses) {
+      lastSeen[key] = rows.filter(e => (e.status || "").toUpperCase() === key).map(e => e.remoteId);
+    }
+    persistLedger({ lastSeen, lastFetchedAt: Date.now(), lastStatuses: [...selectedStatuses] });
+  }
+
+  function previouslySeenIds(): Set<string> {
+    return new Set(Object.values(ledger.lastSeen).flat());
+  }
+
+  async function refreshSnapshot() {
+    snapshotLoading = true;
+    try {
+      const [remote, local] = await Promise.all([
+        tsunagu.trackerLibrary(trackerKey, "MANGA" as ContentType, STATUSES.map(s => s.key)),
+        tsunagu.library("MANGA").catch(() => []),
+      ]);
+      if (cancelled) return;
+      listSnapshot = remote;
+      pulledIds = local.flatMap(m => (m.trackLinks ?? []).filter(l => l.trackerKey === trackerKey).map(l => l.remoteId));
+    } catch {
+      listSnapshot = [];
+    } finally {
+      snapshotLoading = false;
+    }
+  }
+
+  function readCache(): CachePayload | null {
+    if (typeof localStorage === "undefined") return null;
+    try {
+      const raw = localStorage.getItem(cacheKey());
+      if (!raw) return null;
+      const p = JSON.parse(raw) as CachePayload;
+      if (p.v !== CACHE_VER || p.trackerKey !== trackerKey || !Array.isArray(p.entries) || p.entries.length === 0) return null;
+      return p;
+    } catch {
+      return null;
+    }
+  }
+
+  function applyCache(p: CachePayload) {
+    selectedStatuses = p.statuses.length ? [...p.statuses] : selectedStatuses;
+    targetSource = sourceById(p.sourceId);
+    massSourceId = p.sourceId;
+    entries = p.entries.map(e => ({
+      remote: e.remote,
+      match: fromCachedMatch(e.match),
+      similarity: e.similarity,
+      status: e.status === "searching" ? "pending" : e.status,
+      sourceId: e.sourceId,
+      error: e.error,
+      fresh: ledger.lastFetchedAt > 0 && !previouslySeenIds().has(e.remote.remoteId) && e.status !== "already" && e.status !== "imported",
+    }));
+    searchProgress = { done: p.searchDone, total: p.searchTotal || p.entries.length };
+  }
+
+  function draftSourceName(): string {
+    if (!draft) return "";
+    return allSources.find(s => s.id === draft!.sourceId)?.displayName ?? "source";
+  }
+
+  function onKey(e: KeyboardEvent) {
+    if (e.key !== "Escape") return;
+    if (phase === "matching" || phase === "importing") stopWork();
+    else close();
+  }
+
+  function stopWork() {
+    halt = true;
+  }
+
+  function close() {
+    halt = true;
+    cancelled = true;
+    persistCache();
+    if (listSnapshot.length) rememberSeen(listSnapshot, STATUSES.map(s => s.key));
+    persistLedger({ lastStatuses: [...selectedStatuses] });
+    onClose();
+  }
+
+  $effect(() => {
+    tsunagu.installedExtensions()
+      .then(exts => {
+        allSources = exts
+          .filter(e => e.installed && e.contentType === "MANGA")
+          .map(toSource);
+        const prefLang = settingsState.settings.preferredExtensionLang ?? "";
+        const langs = new Set(allSources.map(s => s.lang));
+        if (prefLang && langs.has(prefLang) && langs.size > 1) selectedLang = prefLang;
+        draft = readCache();
+        ledger = readLedger();
+        if (!draft && ledger.lastStatuses.length) selectedStatuses = [...ledger.lastStatuses];
+        void refreshSnapshot();
+      })
+      .catch(console.error)
+      .finally(() => { loadingSources = false; });
+
+    window.addEventListener("keydown", onKey);
+    return () => {
+      halt = true;
+      cancelled = true;
+      window.removeEventListener("keydown", onKey);
+    };
+  });
+
+  function toggleStatus(key: string) {
+    if (selectedStatuses.includes(key)) {
+      if (selectedStatuses.length === 1) return;
+      selectedStatuses = selectedStatuses.filter(s => s !== key);
+    } else {
+      selectedStatuses = [...selectedStatuses, key];
+    }
+    persistLedger({ lastStatuses: [...selectedStatuses] });
+  }
+
+  function scrollLangStrip(dir: -1 | 1) {
+    if (!langStripEl) return;
+    const chips = Array.from(langStripEl.children) as HTMLElement[];
+    const viewEnd = langStripEl.scrollLeft + langStripEl.clientWidth;
+    if (dir === 1) {
+      const next = chips.find(c => c.offsetLeft + c.offsetWidth > viewEnd + 2);
+      if (next) langStripEl.scrollTo({ left: next.offsetLeft, behavior: "smooth" });
+    } else {
+      const prev = [...chips].reverse().find(c => c.offsetLeft < langStripEl!.scrollLeft - 2);
+      if (prev) langStripEl.scrollTo({ left: prev.offsetLeft + prev.offsetWidth - langStripEl.clientWidth, behavior: "smooth" });
+    }
+  }
+
+  function patchEntry(remoteId: string, patch: Partial<EntryResult>) {
+    entries = entries.map(e => e.remote.remoteId === remoteId ? { ...e, ...patch } : e);
+  }
+
+  async function matchOnSource(source: Source, remote: TrackerLibraryEntry): Promise<Pick<EntryResult, "match" | "similarity" | "status" | "error">> {
+    let best: { manga: Manga; similarity: number } | null = null;
+    try {
+      for (const q of searchQueries(remote)) {
+        const resp = await tsunagu.search(source.id, q, 1);
+        for (const r of resp.results) {
+          const similarity = scoreHit(remote, r.title);
+          const manga = toBrowseManga(r, source.id);
+          if (!best || similarity > best.similarity) best = { manga, similarity };
+        }
+        if (best && best.similarity >= GOOD_ENOUGH) break;
+      }
+    } catch (e: any) {
+      return { match: null, similarity: 0, status: "no-match", error: e?.message ?? String(e) };
+    }
+
+    if (best && best.manga.inLibrary) {
+      return { match: best.manga, similarity: best.similarity, status: "already" };
+    }
+    if (best && best.similarity > MATCH_THRESHOLD) {
+      return { match: best.manga, similarity: best.similarity, status: "found" };
+    }
+    return { match: null, similarity: best?.similarity ?? 0, status: "no-match" };
+  }
+
+  async function startSearch(target: Source) {
+    halt = false;
+    targetSource = target;
+    massSourceId = target.id;
+    selectedIds = [];
+    phase = "matching";
+    entries = [];
+    searchProgress = { done: 0, total: 0 };
+
+    let remote: TrackerLibraryEntry[];
+    try {
+      remote = await tsunagu.trackerLibrary(trackerKey, "MANGA" as ContentType, selectedStatuses);
+    } catch (e: any) {
+      phase = "pick-target";
+      addToast({ kind: "error", title: "Couldn't fetch AniList list", body: e?.message ?? String(e) });
+      return;
+    }
+    if (cancelled || halt) return;
+
+    const local = await tsunagu.library("MANGA").catch(() => []);
+    const alreadyByRemote = new Set(
+      local.flatMap(m => (m.trackLinks ?? []).filter(l => l.trackerKey === trackerKey).map(l => l.remoteId)),
+    );
+    pulledIds = [...alreadyByRemote];
+    const seen = previouslySeenIds();
+    const hasHistory = ledger.lastFetchedAt > 0;
+
+    entries = remote.map(r => ({
+      remote: r,
+      match: null,
+      similarity: 0,
+      status: alreadyByRemote.has(r.remoteId) ? "already" : "pending",
+      sourceId: target.id,
+      fresh: hasHistory && !seen.has(r.remoteId) && !alreadyByRemote.has(r.remoteId),
+    }));
+    entries.sort((a, b) => {
+      if (a.status === "already" && b.status !== "already") return 1;
+      if (b.status === "already" && a.status !== "already") return -1;
+      if (a.fresh && !b.fresh) return -1;
+      if (b.fresh && !a.fresh) return 1;
+      return 0;
+    });
+    searchProgress = { done: 0, total: entries.length };
+    rememberSeen(remote, selectedStatuses);
+    persistCache();
+    await continueMatching();
+  }
+
+  async function resumeFromDraft() {
+    if (!draft) return;
+    halt = false;
+    cancelled = false;
+    applyCache(draft);
+    selectedIds = [];
+    if (!targetSource) {
+      addToast({ kind: "error", title: "Source no longer installed" });
+      return;
+    }
+    if (pendingCount > 0) {
+      await continueMatching();
+      return;
+    }
+    phase = foundCount > 0 || noMatchCount > 0 || pendingCount > 0 ? "assign" : "done";
+  }
+
+  async function continueMatching() {
+    const target = targetSource;
+    if (!target) return;
+    halt = false;
+    phase = "matching";
+
+    for (let i = 0; i < entries.length; i++) {
+      if (cancelled) return;
+      if (halt) break;
+      if (entries[i].status !== "pending") continue;
+      entries[i] = { ...entries[i], status: "searching" };
+      const result = await matchOnSource(target, entries[i].remote);
+      if (cancelled) return;
+      entries[i] = { ...entries[i], ...result, sourceId: target.id };
+      searchProgress = {
+        done: entries.filter(e => e.status !== "pending" && e.status !== "searching").length,
+        total: entries.length,
+      };
+      persistCache();
+      if (i + 1 < entries.length && !cancelled && !halt) await sleep(SEARCH_GAP_MS);
+    }
+    if (cancelled) return;
+    persistCache();
+    if (halt) {
+      halt = false;
+      phase = "assign";
+      return;
+    }
+    if (entries.every(e => e.status !== "no-match" && e.status !== "pending")) {
+      await startImport();
+      return;
+    }
+    phase = "assign";
+  }
+
+  async function searchRow(remoteId: string, sourceId: string) {
+    const source = sourceById(sourceId);
+    const entry = entries.find(e => e.remote.remoteId === remoteId);
+    if (!source || !entry) return;
+    patchEntry(remoteId, { status: "searching", sourceId, match: null, error: undefined });
+    const result = await matchOnSource(source, entry.remote);
+    if (cancelled) return;
+    patchEntry(remoteId, { ...result, sourceId });
+    persistCache();
+    if (result.status !== "no-match") {
+      selectedIds = selectedIds.filter(id => id !== remoteId);
+    }
+  }
+
+  async function searchSelected() {
+    halt = false;
+    cancelled = false;
+    const source = sourceById(massSourceId) ?? targetSource;
+    const ids = selectedIds.filter(id => missingIds.includes(id));
+    if (!source || ids.length === 0) return;
+    for (let i = 0; i < ids.length; i++) {
+      if (cancelled || halt) return;
+      await searchRow(ids[i], source.id);
+      if (i + 1 < ids.length && !cancelled && !halt) await sleep(SEARCH_GAP_MS);
+    }
+  }
+
+  function toggleRow(remoteId: string) {
+    selectedIds = selectedIds.includes(remoteId)
+      ? selectedIds.filter(id => id !== remoteId)
+      : [...selectedIds, remoteId];
+  }
+
+  function toggleAllMissing() {
+    selectedIds = allMissingSelected ? [] : [...missingIds];
+  }
+
+  function setDefaultSource(id: string) {
+    const src = sourceById(id);
+    if (!src) return;
+    targetSource = src;
+    massSourceId = src.id;
+    entries = entries.map(e =>
+      e.status === "no-match" || e.status === "pending" ? { ...e, sourceId: src.id } : e,
+    );
+    persistCache();
+  }
+
+  function excludeEntry(idx: number) {
+    const id = entries[idx].remote.remoteId;
+    entries[idx] = { ...entries[idx], status: "skipped", match: null };
+    selectedIds = selectedIds.filter(x => x !== id);
+    persistCache();
+  }
+
+  async function importOne(entry: EntryResult) {
+    const src = sourceById(entry.sourceId);
+    if (!src) throw new Error("No source for this title");
+    if (!entry.match?.sourceEntryId) throw new Error("No match for this title");
+    const info = await tsunagu.mangaInfo(src.id, entry.match.sourceEntryId, true);
+    if (!info.inLibrary) await tsunagu.setInLibrary(info.id, true);
+    if (trackerKey === "anilist") {
+      try {
+        await tsunagu.applyMetadataMatch(info.id, entry.remote.remoteId, "anilist");
+      } catch { /* metadata is optional; tracking still binds */ }
+    }
+    const link = await tsunagu.bindTrack(info.id, trackerKey, entry.remote.remoteId);
+    await tsunagu.updateTrack(link.id, {
+      status: alStatusToTrack(entry.remote.status),
+      score: entry.remote.score,
+      lastChapterRead: entry.remote.progress,
+    });
+    await tsunagu.pullTracker(info.id).catch(() => {});
+    if (!pulledIds.includes(entry.remote.remoteId)) pulledIds = [...pulledIds, entry.remote.remoteId];
+  }
+
+  async function retryImport(remoteId: string) {
+    const idx = entries.findIndex(e => e.remote.remoteId === remoteId);
+    if (idx < 0 || retryingIds.includes(remoteId)) return;
+    const entry = entries[idx];
+    if (!entry.match) {
+      const src = sourceById(entry.sourceId);
+      if (src) await searchRow(remoteId, src.id);
+      return;
+    }
+    halt = false;
+    cancelled = false;
+    retryingIds = [...retryingIds, remoteId];
+    try {
+      if (dryRun) {
+        entries[idx] = { ...entries[idx], status: "imported", error: undefined };
+      } else {
+        await importOne(entry);
+        entries[idx] = { ...entries[idx], status: "imported", error: undefined };
+        await loadLibrary(true);
+        void refreshSnapshot();
+      }
+      persistCache();
+    } catch (e: unknown) {
+      entries[idx] = { ...entries[idx], status: "failed", error: sourceErrorLabel(e) };
+      persistCache();
+    } finally {
+      retryingIds = retryingIds.filter(id => id !== remoteId);
+    }
+  }
+
+  async function startImport() {
+    const toImport = entries.filter(e => e.status === "found" && e.match);
+    if (toImport.length === 0) {
+      phase = (noMatchCount > 0 || pendingCount > 0 || failedCount > 0) ? "assign" : "done";
+      return;
+    }
+    importProgress = { done: 0, total: toImport.length, failed: 0 };
+    phase = "importing";
+
+    for (const entry of toImport) {
+      if (cancelled) return;
+      if (halt) break;
+      const idx = entries.findIndex(e => e.remote.remoteId === entry.remote.remoteId);
+      if (idx < 0) continue;
+      try {
+        if (dryRun) {
+          entries[idx] = { ...entries[idx], status: "imported" };
+        } else {
+          await importOne(entry);
+          entries[idx] = { ...entries[idx], status: "imported" };
+        }
+        importProgress = { ...importProgress, done: importProgress.done + 1 };
+      } catch (e: unknown) {
+        entries[idx] = { ...entries[idx], status: "failed", error: sourceErrorLabel(e) };
+        importProgress = { ...importProgress, done: importProgress.done + 1, failed: importProgress.failed + 1 };
+      }
+      persistCache();
+    }
+
+    if (!dryRun) {
+      await loadLibrary(true);
+      void refreshSnapshot();
+    }
+
+    if (halt) {
+      halt = false;
+      phase = "assign";
+      return;
+    }
+
+    if (entries.some(e => e.status === "no-match" || e.status === "pending" || e.status === "found" || e.status === "failed")) {
+      persistCache();
+      phase = "assign";
+      addToast({
+        kind: "success",
+        title: dryRun ? "Dry run complete" : "Imported matched titles",
+        body: `${importProgress.done - importProgress.failed} imported, ${noMatchCount + pendingCount} still unmatched`,
+      });
+      return;
+    }
+
+    clearCache();
+    phase = "done";
+    addToast({
+      kind: "success",
+      title: dryRun ? "Dry run complete" : "Import complete",
+      body: `${importProgress.done - importProgress.failed} imported, ${importProgress.failed} failed`,
+    });
+  }
+
+  function exportFailed() {
+    const rows = entries
+      .filter(e => e.status === "failed" || e.status === "no-match" || e.status === "skipped")
+      .map(e => ({
+        remoteId: e.remote.remoteId,
+        title: displayTitle(e.remote),
+        titleEnglish: e.remote.titleEnglish,
+        titleRomaji: e.remote.titleRomaji,
+        url: e.remote.url,
+        result: e.status,
+        error: e.error ?? null,
+        matchedTitle: e.match?.title ?? null,
+      }));
+    const blob = new Blob([JSON.stringify(rows, null, 2)], { type: "application/json" });
+    const a = document.createElement("a");
+    a.href = URL.createObjectURL(blob);
+    a.download = `anilist-import-${trackerKey}-failed.json`;
+    a.click();
+    URL.revokeObjectURL(a.href);
+  }
+
+  const helloName = $derived((username ?? "").trim());
+</script>
+
+<div class="overlay" role="presentation" onclick={(e) => { if (e.target === e.currentTarget && phase !== "importing") close(); }} onkeydown={(e) => { if (e.key === "Escape" && phase !== "importing") close(); }}>
+  <div class="modal" class:modal-wide={phase === "assign"} class:modal-fill={phase === "matching" || phase === "assign" || phase === "importing"}>
+
+    <div class="modal-header">
+      <div class="source-context">
+        <div class="source-icon-wrap logo">
+          <TrackerLogo trackerKey={trackerKey} size={22} />
+        </div>
+        <div class="source-context-info">
+          <span class="modal-eyebrow">Library import</span>
+          <span class="modal-title">Import from {trackerName}</span>
+          <span class="modal-sub">Manga only · match titles on one source, then assign the rest</span>
+        </div>
+      </div>
+      {#if phase !== "importing"}
+        <button class="close-btn" onclick={close}><X size={14} weight="light" /></button>
+      {/if}
+    </div>
+
+    <div class="body">
+
+      {#if phase === "pick-target"}
+        {#if draft}
+          <div class="resume-banner">
+            <div class="resume-copy">
+              <span class="resume-title">Resume import</span>
+              <span class="resume-sub">{draftSourceName()} · {draft.searchDone} / {draft.searchTotal} searched</span>
+            </div>
+            <button class="back-btn" onclick={clearCache}><Trash size={12} weight="light" /> Discard</button>
+            <button class="migrate-btn" onclick={() => void resumeFromDraft()}>
+              <Play size={12} weight="bold" /> Resume
+            </button>
+          </div>
+        {/if}
+        <div class="phase-label-row">
+          <span class="phase-label">List statuses</span>
+        </div>
+        <div class="status-chips">
+          {#each STATUSES as s}
+            <button
+              class="status-chip"
+              class:status-chip-active={selectedStatuses.includes(s.key)}
+              onclick={() => toggleStatus(s.key)}
+            >
+              {s.label}
+              {#if statusCounts[s.key]?.neu}
+                <span class="chip-badge chip-badge-new">{statusCounts[s.key].left} · {statusCounts[s.key].neu} new</span>
+              {:else if statusCounts[s.key]?.left}
+                <span class="chip-badge">{statusCounts[s.key].left}</span>
+              {/if}
+            </button>
+          {/each}
+        </div>
+        {#if snapshotLoading}
+          <p class="list-hint">Checking AniList lists…</p>
+        {:else if listSnapshot.length > 0}
+          <p class="list-hint">
+            {leftoverTotal} not in library
+            {#if newTotal > 0} · {newTotal} new on AniList{/if}
+            {#if ledger.lastFetchedAt}
+              · last sync {new Date(ledger.lastFetchedAt).toLocaleDateString()}
+            {/if}
+          </p>
+        {/if}
+
+        <div class="phase-label-row">
+          <span class="phase-label">Default destination source</span>
+        </div>
+        {#if loadingSources}
+          <div class="centered"><CircleNotch size={16} weight="light" class="anim-spin" style="color:var(--text-faint)" /></div>
+        {:else if allSources.length === 0}
+          <div class="centered"><span class="hint">Install a manga source first.</span></div>
+        {:else}
+          {#if hasMultipleLangs}
+            <div class="src-lang-bar">
+              <button class="src-lang-nav" onclick={() => scrollLangStrip(-1)}>‹</button>
+              <div class="src-lang-chips" bind:this={langStripEl}>
+                <button class="src-lang-chip" class:src-lang-chip-active={selectedLang === "all"} onclick={() => selectedLang = "all"}>All</button>
+                {#each availableLangs as lang}
+                  <button class="src-lang-chip" class:src-lang-chip-active={selectedLang === lang} onclick={() => selectedLang = lang}>
+                    {lang.toUpperCase()}
+                  </button>
+                {/each}
+              </div>
+              <button class="src-lang-nav" onclick={() => scrollLangStrip(1)}>›</button>
+            </div>
+          {/if}
+          <div class="source-list">
+            {#each visibleSources as src}
+              <button class="source-row" onclick={() => startSearch(src)}>
+                <div class="source-icon-wrap">
+                  <ExtensionIcon src={src.iconUrl} alt={src.name} class="source-icon" size={36} />
+                </div>
+                <div class="source-info">
+                  <span class="source-name">{src.displayName}</span>
+                  <span class="source-meta">{src.lang.toUpperCase()}{src.isNsfw ? " · NSFW" : ""}</span>
+                </div>
+                <ArrowRight size={13} weight="light" class="source-arrow" />
+              </button>
+            {/each}
+          </div>
+        {/if}
+
+      {:else if phase === "matching" || phase === "importing"}
+        <div class="review-header">
+          <div class="review-route">
+            <div class="review-source">
+              <TrackerLogo trackerKey={trackerKey} size={16} />
+              <span class="review-source-name">{trackerName}</span>
+            </div>
+            <ArrowRight size={14} weight="light" style="color:var(--text-faint);flex-shrink:0" />
+            {#if targetSource}
+              <div class="review-source">
+                <div class="source-icon-wrap small">
+                  <ExtensionIcon src={targetSource.iconUrl} alt={targetSource.name} class="source-icon" size={20} />
+                </div>
+                <span class="review-source-name">{targetSource.displayName}</span>
+              </div>
+            {/if}
+          </div>
+
+          {#if phase === "matching"}
+            <div class="review-progress-row">
+              <div class="review-progress-bar">
+                <div class="review-progress-fill" style="width:{searchProgress.total ? (searchProgress.done / searchProgress.total) * 100 : 0}%"></div>
+              </div>
+              <span class="review-progress-label">
+                {#if searchProgress.done < searchProgress.total}
+                  Searching {searchProgress.done} / {searchProgress.total}…
+                {:else}
+                  {foundCount} found · {alreadyCount} already · {noMatchCount} missing
+                {/if}
+              </span>
+              <button class="stop-btn" onclick={stopWork} title="Stop matching">
+                <Pause size={11} weight="fill" /> Stop
+              </button>
+            </div>
+          {:else}
+            <div class="review-progress-row">
+              <div class="review-progress-bar">
+                <div class="review-progress-fill" style="width:{importProgress.total ? (importProgress.done / importProgress.total) * 100 : 0}%"></div>
+              </div>
+              <span class="review-progress-label">{dryRun ? "Dry run" : "Importing"} {importProgress.done} / {importProgress.total}…</span>
+              <button class="stop-btn" onclick={stopWork} title="Stop import">
+                <Pause size={11} weight="fill" /> Stop
+              </button>
+            </div>
+          {/if}
+        </div>
+
+        <div class="entry-list">
+          {#each entries as entry}
+            <div class="entry-row" class:entry-imported={entry.status === "imported"} class:entry-failed={entry.status === "failed"} class:entry-already={entry.status === "already"}>
+              <div class="entry-cover-wrap">
+                <Thumbnail src={entry.remote.coverUrl ?? ""} alt={displayTitle(entry.remote)} class="entry-cover" />
+              </div>
+              <div class="entry-info">
+                <span class="entry-title">
+                  <span class="entry-title-text">{displayTitle(entry.remote)}</span>
+                  {#if entry.fresh}<span class="new-pill">New</span>{/if}
+                </span>
+                {#if displaySub(entry.remote)}
+                  <span class="entry-sub">{displaySub(entry.remote)}</span>
+                {/if}
+                {#if entry.status === "found" && entry.match}
+                  <span class="entry-match">
+                    <Sparkle size={9} weight="fill" style="color:var(--accent-fg);flex-shrink:0" />
+                    {entry.match.title}
+                    <span class="entry-sim">{Math.round(entry.similarity * 100)}%</span>
+                    <span class="entry-prog">ch. {entry.remote.progress}</span>
+                  </span>
+                {:else if entry.status === "no-match"}
+                  <span class="entry-no-match">No match found</span>
+                {:else if entry.status === "already"}
+                  <span class="entry-already-label">Already in library</span>
+                {:else if entry.status === "skipped"}
+                  <span class="entry-no-match">Skipped</span>
+                {:else if entry.status === "searching"}
+                  <span class="entry-searching">Searching…</span>
+                {:else if entry.status === "imported"}
+                  <span class="entry-done">{dryRun ? "Would import" : "Imported"}</span>
+                {:else if entry.status === "failed"}
+                  <span class="entry-fail">{entry.error ?? "Failed"}</span>
+                {:else if !displaySub(entry.remote)}
+                  <span class="entry-searching">{entry.remote.status} · ch. {entry.remote.progress}</span>
+                {/if}
+              </div>
+              <div class="entry-status">
+                {#if entry.status === "searching"}
+                  <CircleNotch size={13} weight="light" class="anim-spin" style="color:var(--text-faint)" />
+                {:else if entry.status === "found" && entry.match}
+                  <div class="entry-cover-match">
+                    <Thumbnail src={entry.match.thumbnailUrl} alt={entry.match.title} class="entry-match-cover" />
+                  </div>
+                {:else if entry.status === "imported"}
+                  <Check size={13} weight="bold" style="color:var(--color-success)" />
+                {:else if entry.status === "failed"}
+                  <Warning size={13} weight="light" style="color:var(--color-error)" />
+                {:else if entry.status === "already"}
+                  <Check size={13} weight="light" style="color:var(--text-faint)" />
+                {/if}
+              </div>
+            </div>
+          {/each}
+        </div>
+
+      {:else if phase === "assign"}
+        <div class="assign-summary">
+          <span class="assign-stats">
+            {#if foundCount > 0}<span class="stat-ready">{foundCount} ready to import</span>{/if}
+            {#if foundCount > 0 && missingEntries.length > 0}<span class="stat-dot">·</span>{/if}
+            {#if missingEntries.length > 0}<span class="stat-unmatched">{missingEntries.length} unmatched</span>{/if}
+            {#if (foundCount > 0 || missingEntries.length > 0) && alreadyCount > 0}<span class="stat-dot">·</span>{/if}
+            {#if alreadyCount > 0}<span class="stat-already">{alreadyCount} already in library</span>{/if}
+          </span>
+          {#if assignSources.length > 0}
+            <label class="assign-default">
+              Default
+              <select
+                class="src-select"
+                value={targetSource?.id ?? massSourceId}
+                disabled={assignSources.length === 0}
+                onchange={(e) => setDefaultSource((e.currentTarget as HTMLSelectElement).value)}
+              >
+                {#each assignSources as src}
+                  <option value={src.id}>{sourceLabel(src)}</option>
+                {/each}
+              </select>
+            </label>
+          {/if}
+        </div>
+
+        <div class="mass-bar">
+          <label class="mass-check">
+            <input class="s-check" type="checkbox" checked={allMissingSelected} onchange={toggleAllMissing} />
+            {selectedMissing} selected
+          </label>
+          <button
+            class="migrate-btn mass-search-btn"
+            onclick={() => void searchSelected()}
+            disabled={selectedMissing === 0 || !(massSourceId || targetSource)}
+          >
+            <ArrowsClockwise size={12} weight="bold" />
+            Search {selectedMissing}
+          </button>
+        </div>
+
+        <div class="table-wrap">
+          <table class="assign-table">
+            <thead>
+              <tr>
+                <th class="col-check"></th>
+                <th class="col-title">Title</th>
+                <th class="col-prog">Ch.</th>
+                <th class="col-src">Source</th>
+                <th class="col-stat">Match</th>
+              </tr>
+            </thead>
+            <tbody>
+              {#each assignRows as { e: entry, idx } (entry.remote.remoteId)}
+                <tr class:row-ok={entry.status === "found" || entry.status === "imported"}>
+                  <td class="col-check">
+                    {#if entry.status === "no-match" || entry.status === "searching" || entry.status === "pending"}
+                      <input
+                        class="s-check"
+                        type="checkbox"
+                        checked={selectedIds.includes(entry.remote.remoteId)}
+                        disabled={entry.status === "searching"}
+                        onchange={() => toggleRow(entry.remote.remoteId)}
+                      />
+                    {/if}
+                  </td>
+                    <td class="col-title">
+                      <div class="table-title">
+                        <div class="entry-cover-wrap">
+                          <Thumbnail src={entry.remote.coverUrl ?? ""} alt={displayTitle(entry.remote)} class="entry-cover" />
+                        </div>
+                        <div class="entry-info">
+                          <span class="entry-title">
+                            <span class="entry-title-text">{displayTitle(entry.remote)}</span>
+                            {#if entry.fresh}<span class="new-pill">New</span>{/if}
+                          </span>
+                          {#if entry.match && (entry.status === "found" || entry.status === "imported")}
+                            <span class="entry-sub">{entry.match.title}</span>
+                          {:else if displaySub(entry.remote)}
+                            <span class="entry-sub">{displaySub(entry.remote)}</span>
+                          {/if}
+                        </div>
+                      </div>
+                    </td>
+                    <td class="col-prog">{entry.remote.progress}</td>
+                    <td class="col-src">
+                      {#if entry.status === "imported"}
+                        {@const src = sourceById(entry.sourceId)}
+                        <span class="src-static">{src ? sourceLabel(src) : "—"}</span>
+                      {:else}
+                        <select
+                          class="src-select"
+                          value={entry.sourceId ?? targetSource?.id ?? ""}
+                          disabled={entry.status === "searching" || retryingIds.includes(entry.remote.remoteId)}
+                          onchange={(e) => void searchRow(entry.remote.remoteId, (e.currentTarget as HTMLSelectElement).value)}
+                        >
+                          {#each assignSources as src}
+                            <option value={src.id}>{sourceLabel(src)}</option>
+                          {/each}
+                        </select>
+                      {/if}
+                    </td>
+                    <td class="col-stat">
+                      <div class="stat-cell">
+                        {#if entry.status === "searching" || retryingIds.includes(entry.remote.remoteId)}
+                          <CircleNotch size={13} weight="light" class="anim-spin" style="color:var(--text-faint)" />
+                        {:else if entry.status === "pending"}
+                          <span class="entry-searching">Not searched</span>
+                        {:else if entry.status === "found"}
+                          <Check size={13} weight="bold" style="color:var(--color-success)" />
+                          <span class="entry-done">Matched</span>
+                        {:else if entry.status === "imported"}
+                          <Check size={13} weight="bold" style="color:var(--color-success)" />
+                          <span class="entry-done">Imported</span>
+                        {:else if entry.status === "failed"}
+                          <Warning size={13} weight="light" style="color:var(--color-error)" />
+                          <span class="entry-fail" title={entry.error}>{sourceErrorLabel(entry.error)}</span>
+                          <button class="entry-exclude-btn" onclick={() => void retryImport(entry.remote.remoteId)} title="Retry import">
+                            <ArrowsClockwise size={11} weight="bold" />
+                          </button>
+                        {:else if entry.status === "skipped"}
+                          <span class="entry-no-match">Skipped</span>
+                        {:else}
+                          <span class="entry-no-match">No match</span>
+                          <button class="entry-exclude-btn" onclick={() => excludeEntry(idx)} title="Skip this title">
+                            <X size={10} weight="bold" />
+                          </button>
+                        {/if}
+                      </div>
+                    </td>
+                  </tr>
+              {/each}
+            </tbody>
+          </table>
+        </div>
+
+        <div class="review-actions">
+          <div class="dry-run">
+            <span>Dry run</span>
+            <button
+              type="button"
+              class="s-toggle"
+              class:on={dryRun}
+              role="switch"
+              aria-checked={dryRun}
+              aria-label="Dry run"
+              onclick={() => (dryRun = !dryRun)}
+            ><span class="s-toggle-thumb"></span></button>
+          </div>
+          {#if pendingCount > 0}
+            <button class="back-btn" onclick={() => void continueMatching()}>
+              <Play size={12} weight="bold" /> Resume search
+            </button>
+          {/if}
+          <button class="migrate-btn" onclick={() => void startImport()} disabled={foundCount === 0}>
+            <TrayArrowDown size={13} weight="bold" />
+            Import {foundCount} matched
+          </button>
+        </div>
+
+      {:else if phase === "done"}
+        <div class="welcome">
+          <div class="welcome-check"><Check size={22} weight="bold" /></div>
+          <h2 class="welcome-title">{helloName ? `Welcome home, ${helloName}` : "Welcome home"}</h2>
+          <p class="welcome-sub">
+            {importedCount} imported
+            {#if alreadyCount > 0} · {alreadyCount} already in library{/if}
+            {#if skippedCount > 0} · {skippedCount} skipped{/if}
+            {#if failedCount > 0} · {failedCount} failed{/if}
+            {#if dryRun} · dry run{/if}
+          </p>
+        </div>
+        <div class="review-actions">
+          {#if noMatchCount + failedCount + skippedCount > 0}
+            <button class="back-btn" onclick={exportFailed}>
+              <DownloadSimple size={12} weight="light" /> Export leftover
+            </button>
+          {/if}
+            <button class="migrate-btn" onclick={() => { clearCache(); onDone(); }}><Check size={13} weight="bold" /> Done</button>
+        </div>
+      {/if}
+
+    </div>
+  </div>
+</div>
+
+<style>
+  .overlay { position: fixed; inset: 0; padding: 24px; background: rgba(0,0,0,0.6); display: flex; align-items: center; justify-content: center; z-index: calc(var(--z-settings) + 2); animation: fadeIn 0.1s ease both; overflow: hidden; }
+  .modal { background: var(--bg-base); border: 1px solid var(--border-base); border-radius: var(--radius-xl); width: 560px; max-height: 100%; min-height: 0; display: flex; flex-direction: column; overflow: hidden; box-shadow: 0 8px 40px rgba(0,0,0,0.5); }
+  .modal-wide { width: min(860px, 100%); }
+  .modal-fill { align-self: stretch; }
+
+  .modal-header { display: flex; align-items: flex-start; justify-content: space-between; gap: var(--sp-3); padding: var(--sp-4) var(--sp-5); border-bottom: 1px solid var(--border-dim); flex-shrink: 0; }
+  .source-context { display: flex; align-items: center; gap: var(--sp-3); min-width: 0; }
+  .source-icon-wrap { width: 36px; height: 36px; border-radius: var(--radius-md); overflow: hidden; flex-shrink: 0; background: var(--bg-raised); border: 1px solid var(--border-dim); }
+  .source-icon-wrap.logo { display: flex; align-items: center; justify-content: center; }
+  .source-icon-wrap.small { width: 20px; height: 20px; border-radius: var(--radius-sm); }
+  :global(.source-icon) { width: 100%; height: 100%; object-fit: cover; }
+  .source-context-info { display: flex; flex-direction: column; gap: 2px; min-width: 0; }
+  .modal-eyebrow { font-family: var(--font-ui); font-size: var(--text-2xs); color: var(--text-faint); letter-spacing: var(--tracking-wider); text-transform: uppercase; }
+  .modal-title { font-size: var(--text-base); font-weight: var(--weight-medium); color: var(--text-primary); letter-spacing: var(--tracking-tight); }
+  .modal-sub { font-family: var(--font-ui); font-size: var(--text-2xs); color: var(--text-faint); letter-spacing: var(--tracking-wide); }
+  .close-btn { display: flex; align-items: center; justify-content: center; width: 24px; height: 24px; border-radius: var(--radius-md); color: var(--text-faint); background: none; border: none; cursor: pointer; transition: color var(--t-base), background var(--t-base); flex-shrink: 0; margin-top: 2px; }
+  .close-btn:hover { color: var(--text-muted); background: var(--bg-raised); }
+
+  .body { flex: 1; overflow: hidden; display: flex; flex-direction: column; min-height: 0; }
+
+  .phase-label-row { padding: var(--sp-3) var(--sp-4) var(--sp-2); flex-shrink: 0; }
+  .phase-label { font-family: var(--font-ui); font-size: var(--text-2xs); color: var(--text-faint); letter-spacing: var(--tracking-widest); text-transform: uppercase; }
+  .centered { flex: 1; display: flex; align-items: center; justify-content: center; padding: var(--sp-8); }
+  .hint { font-family: var(--font-ui); font-size: var(--text-xs); color: var(--text-faint); letter-spacing: var(--tracking-wide); }
+
+  .status-chips { display: flex; flex-wrap: wrap; gap: var(--sp-1); padding: 0 var(--sp-4) var(--sp-2); flex-shrink: 0; }
+  .status-chip { font-family: var(--font-ui); font-size: var(--text-2xs); letter-spacing: var(--tracking-wide); padding: 3px 8px; border-radius: var(--radius-sm); border: 1px solid var(--border-dim); background: none; color: var(--text-faint); cursor: pointer; white-space: nowrap; transition: color var(--t-base), border-color var(--t-base), background var(--t-base); display: inline-flex; align-items: center; gap: 6px; }
+  .status-chip:hover { color: var(--text-muted); background: var(--bg-raised); }
+  .status-chip-active { color: var(--accent-fg); border-color: var(--accent-dim); background: var(--accent-muted); }
+  .chip-badge { font-size: 9px; letter-spacing: var(--tracking-wide); padding: 0 5px; border-radius: var(--radius-sm); border: 1px solid var(--border-dim); color: var(--text-faint); }
+  .chip-badge-new { color: var(--accent-fg); border-color: var(--accent-dim); background: var(--accent-muted); }
+  .list-hint { margin: 0; padding: 0 var(--sp-4) var(--sp-2); font-family: var(--font-ui); font-size: var(--text-2xs); color: var(--text-faint); letter-spacing: var(--tracking-wide); }
+
+  .src-lang-bar { display: flex; align-items: center; gap: var(--sp-1); padding: var(--sp-2); border-bottom: 1px solid var(--border-dim); flex-shrink: 0; }
+  .src-lang-nav { display: flex; align-items: center; justify-content: center; width: 22px; height: 22px; flex-shrink: 0; border-radius: var(--radius-sm); border: 1px solid var(--border-dim); background: none; color: var(--text-faint); font-size: 15px; line-height: 1; cursor: pointer; transition: color var(--t-base), background var(--t-base); }
+  .src-lang-nav:hover { color: var(--text-muted); background: var(--bg-raised); }
+  .src-lang-chips { display: flex; align-items: center; gap: var(--sp-1); flex: 1; min-width: 0; overflow-x: auto; scrollbar-width: none; }
+  .src-lang-chips::-webkit-scrollbar { display: none; }
+  .src-lang-chip { font-family: var(--font-ui); font-size: var(--text-2xs); letter-spacing: var(--tracking-wide); padding: 3px 8px; border-radius: var(--radius-sm); border: 1px solid var(--border-dim); background: none; color: var(--text-faint); cursor: pointer; white-space: nowrap; flex-shrink: 0; transition: color var(--t-base), border-color var(--t-base), background var(--t-base); }
+  .src-lang-chip:hover { color: var(--text-muted); background: var(--bg-raised); }
+  .src-lang-chip-active { color: var(--accent-fg); border-color: var(--accent-dim); background: var(--accent-muted); }
+
+  .source-list { flex: 1; overflow-y: auto; padding: var(--sp-2); display: flex; flex-direction: column; gap: 1px; }
+  .source-row { display: flex; align-items: center; gap: var(--sp-3); padding: 8px var(--sp-3); border-radius: var(--radius-md); border: 1px solid transparent; background: none; text-align: left; width: 100%; cursor: pointer; transition: background var(--t-fast), border-color var(--t-fast); }
+  .source-row:hover { background: var(--bg-raised); border-color: var(--border-dim); }
+  .source-info { flex: 1; display: flex; flex-direction: column; gap: 2px; overflow: hidden; }
+  .source-name { font-size: var(--text-sm); font-weight: var(--weight-medium); color: var(--text-secondary); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+  .source-meta { font-family: var(--font-ui); font-size: var(--text-2xs); color: var(--text-faint); letter-spacing: var(--tracking-wide); }
+  :global(.source-arrow) { color: var(--text-faint); opacity: 0; transition: opacity var(--t-base); flex-shrink: 0; }
+  .source-row:hover :global(.source-arrow) { opacity: 1; }
+
+  .review-header { padding: var(--sp-3) var(--sp-4); border-bottom: 1px solid var(--border-dim); flex-shrink: 0; display: flex; flex-direction: column; gap: var(--sp-2); }
+  .review-route { display: flex; align-items: center; gap: var(--sp-2); }
+  .review-source { display: flex; align-items: center; gap: var(--sp-2); min-width: 0; }
+  .review-source-name { font-size: var(--text-xs); color: var(--text-secondary); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; font-weight: var(--weight-medium); }
+  .review-progress-row { display: flex; align-items: center; gap: var(--sp-3); }
+  .review-progress-bar { flex: 1; height: 3px; background: var(--bg-overlay); border-radius: var(--radius-full); overflow: hidden; }
+  .review-progress-fill { height: 100%; background: var(--accent); border-radius: var(--radius-full); transition: width 0.3s ease; }
+  .review-progress-label { font-family: var(--font-ui); font-size: var(--text-2xs); color: var(--text-faint); letter-spacing: var(--tracking-wide); white-space: nowrap; flex-shrink: 0; }
+  .stop-btn { display: flex; align-items: center; gap: 4px; font-family: var(--font-ui); font-size: var(--text-2xs); letter-spacing: var(--tracking-wide); padding: 3px 8px; border-radius: var(--radius-sm); background: none; color: var(--text-muted); border: 1px solid var(--border-dim); cursor: pointer; flex-shrink: 0; }
+  .stop-btn:hover { color: var(--color-error); border-color: var(--color-error); background: var(--bg-raised); }
+
+  .resume-banner { display: flex; align-items: center; gap: var(--sp-2); margin: var(--sp-3) var(--sp-4) 0; padding: var(--sp-3); border: 1px solid var(--accent-dim); background: var(--accent-muted); border-radius: var(--radius-md); flex-shrink: 0; }
+  .resume-copy { flex: 1; display: flex; flex-direction: column; gap: 2px; min-width: 0; }
+  .resume-title { font-size: var(--text-sm); font-weight: var(--weight-medium); color: var(--text-primary); }
+  .resume-sub { font-family: var(--font-ui); font-size: var(--text-2xs); color: var(--text-faint); letter-spacing: var(--tracking-wide); }
+
+  .entry-list { flex: 1 1 auto; min-height: 0; overflow-y: auto; padding: var(--sp-2); display: flex; flex-direction: column; gap: 1px; }
+  .entry-row { display: flex; align-items: center; gap: var(--sp-3); padding: 7px var(--sp-3); border-radius: var(--radius-md); border: 1px solid transparent; transition: background var(--t-fast); }
+  .entry-row:hover { background: var(--bg-raised); }
+  .entry-imported { opacity: 0.5; }
+  .entry-already { opacity: 0.65; }
+  .entry-failed { border-color: rgba(180,60,60,0.15); background: rgba(180,60,60,0.04); }
+  .entry-cover-wrap { width: 28px; height: 42px; border-radius: var(--radius-sm); overflow: hidden; background: var(--bg-raised); border: 1px solid var(--border-dim); flex-shrink: 0; }
+  :global(.entry-cover) { width: 100%; height: 100%; object-fit: cover; }
+  .entry-info { flex: 1; display: flex; flex-direction: column; gap: 3px; min-width: 0; overflow: hidden; }
+  .entry-title { display: flex; align-items: center; gap: 6px; min-width: 0; font-size: var(--text-sm); color: var(--text-secondary); }
+  .entry-title-text { white-space: nowrap; overflow: hidden; text-overflow: ellipsis; min-width: 0; }
+  .new-pill { flex-shrink: 0; font-family: var(--font-ui); font-size: 9px; letter-spacing: var(--tracking-wide); text-transform: uppercase; padding: 0 5px; border-radius: var(--radius-sm); color: var(--accent-fg); border: 1px solid var(--accent-dim); background: var(--accent-muted); }
+  .entry-sub { font-family: var(--font-ui); font-size: var(--text-2xs); color: var(--text-faint); letter-spacing: var(--tracking-wide); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+  .entry-match { display: flex; align-items: center; gap: 4px; font-family: var(--font-ui); font-size: var(--text-2xs); color: var(--text-faint); letter-spacing: var(--tracking-wide); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+  .entry-sim { background: var(--bg-overlay); border: 1px solid var(--border-dim); border-radius: var(--radius-sm); padding: 0 4px; font-size: 9px; flex-shrink: 0; }
+  .entry-prog { flex-shrink: 0; }
+  .entry-no-match, .entry-searching, .entry-already-label { font-family: var(--font-ui); font-size: var(--text-2xs); color: var(--text-faint); letter-spacing: var(--tracking-wide); }
+  .entry-done { font-family: var(--font-ui); font-size: var(--text-2xs); color: var(--color-success); letter-spacing: var(--tracking-wide); }
+  .entry-fail { font-family: var(--font-ui); font-size: var(--text-2xs); color: var(--color-error); letter-spacing: var(--tracking-wide); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+  .entry-status { display: flex; align-items: center; gap: var(--sp-1); flex-shrink: 0; }
+  .entry-cover-match { width: 24px; height: 36px; border-radius: var(--radius-sm); overflow: hidden; background: var(--bg-raised); border: 1px solid var(--border-dim); flex-shrink: 0; }
+  :global(.entry-match-cover) { width: 100%; height: 100%; object-fit: cover; }
+  .entry-exclude-btn { display: flex; align-items: center; justify-content: center; width: 18px; height: 18px; border-radius: var(--radius-sm); color: var(--text-faint); background: none; border: none; cursor: pointer; transition: color var(--t-base), background var(--t-base); flex-shrink: 0; }
+  .entry-exclude-btn:hover { color: var(--color-error); background: var(--bg-raised); }
+
+  .assign-summary { display: flex; align-items: center; justify-content: space-between; gap: var(--sp-3); padding: var(--sp-3) var(--sp-4); border-bottom: 1px solid var(--border-dim); flex-shrink: 0; font-family: var(--font-ui); font-size: var(--text-2xs); color: var(--text-faint); letter-spacing: var(--tracking-wide); }
+  .assign-stats { display: flex; align-items: center; gap: 6px; min-width: 0; flex-wrap: wrap; }
+  .stat-ready { color: var(--accent-fg); }
+  .stat-unmatched { color: var(--text-secondary); }
+  .stat-already { color: var(--text-faint); }
+  .stat-dot { color: var(--text-faint); }
+  .assign-default { display: flex; align-items: center; gap: 8px; color: var(--text-muted); flex-shrink: 0; }
+  .mass-bar { display: flex; align-items: center; gap: var(--sp-2); padding: var(--sp-2) var(--sp-4); border-bottom: 1px solid var(--border-dim); flex-shrink: 0; }
+  .mass-check { display: flex; align-items: center; gap: 6px; margin-right: var(--sp-5); font-family: var(--font-ui); font-size: var(--text-2xs); color: var(--text-faint); letter-spacing: var(--tracking-wide); cursor: pointer; white-space: nowrap; }
+  .mass-search-btn { padding: 5px 12px; }
+  .src-select {
+    font-family: var(--font-ui); font-size: var(--text-2xs); letter-spacing: var(--tracking-wide);
+    color: var(--text-secondary); background: var(--bg-raised); border: 1px solid var(--border-dim);
+    border-radius: var(--radius-sm); padding: 4px 8px; min-width: 0; max-width: 220px; cursor: pointer;
+  }
+  .src-select:focus { outline: none; border-color: var(--accent-dim); }
+  .src-select:disabled { opacity: 0.5; cursor: default; }
+  .src-select option { background: var(--bg-surface); color: var(--text-secondary); }
+
+  .table-wrap { flex: 1; overflow: auto; min-height: 0; }
+  .assign-table { width: 100%; table-layout: fixed; border-collapse: collapse; }
+  .assign-table th {
+    position: sticky; top: 0; z-index: 1; background: var(--bg-base);
+    font-family: var(--font-ui); font-size: 10px; letter-spacing: var(--tracking-widest); text-transform: uppercase;
+    color: var(--text-faint); font-weight: var(--weight-medium); text-align: left;
+    padding: 8px var(--sp-3); border-bottom: 1px solid var(--border-dim);
+  }
+  .assign-table td { padding: 6px var(--sp-3); border-bottom: 1px solid var(--border-dim); vertical-align: middle; }
+  .assign-table tbody tr:hover { background: var(--bg-raised); }
+  .col-check { width: 32px; }
+  .col-prog { width: 44px; font-family: var(--font-ui); font-size: var(--text-2xs); color: var(--text-faint); }
+  .col-src { width: 220px; }
+  .col-stat { width: 148px; }
+  .stat-cell { display: flex; align-items: center; gap: 4px; }
+  .col-src .src-select { width: 100%; max-width: none; }
+  .src-static { font-family: var(--font-ui); font-size: var(--text-2xs); color: var(--text-faint); letter-spacing: var(--tracking-wide); }
+  .row-ok { opacity: 0.85; }
+  .table-title { display: flex; align-items: center; gap: var(--sp-3); min-width: 0; }
+
+  .welcome { flex: 1; display: flex; flex-direction: column; align-items: center; justify-content: center; gap: var(--sp-3); padding: var(--sp-8) var(--sp-5); text-align: center; }
+  .welcome-check { width: 48px; height: 48px; border-radius: 50%; display: flex; align-items: center; justify-content: center; background: var(--accent-muted); border: 1px solid var(--accent-dim); color: var(--accent-fg); }
+  .welcome-title { margin: 0; font-size: var(--text-lg); font-weight: var(--weight-medium); color: var(--text-primary); letter-spacing: var(--tracking-tight); }
+  .welcome-sub { margin: 0; font-family: var(--font-ui); font-size: var(--text-xs); color: var(--text-faint); letter-spacing: var(--tracking-wide); }
+
+  .review-actions { display: flex; justify-content: flex-end; align-items: center; gap: var(--sp-2); padding: var(--sp-3) var(--sp-4); border-top: 1px solid var(--border-dim); flex-shrink: 0; }
+  .back-btn { display: flex; align-items: center; gap: 6px; font-family: var(--font-ui); font-size: var(--text-xs); letter-spacing: var(--tracking-wide); padding: 6px 10px; border-radius: var(--radius-md); background: none; color: var(--text-muted); border: 1px solid var(--border-dim); cursor: pointer; transition: color var(--t-base), border-color var(--t-base), background var(--t-base); }
+  .back-btn:hover:not(:disabled) { color: var(--text-secondary); border-color: var(--border-strong); background: var(--bg-raised); }
+  .back-btn:disabled { opacity: 0.4; cursor: default; }
+  .dry-run { display: flex; align-items: center; gap: 8px; margin-right: auto; font-family: var(--font-ui); font-size: var(--text-2xs); color: var(--text-faint); letter-spacing: var(--tracking-wide); }
+  .migrate-btn { display: flex; align-items: center; gap: var(--sp-2); font-family: var(--font-ui); font-size: var(--text-xs); letter-spacing: var(--tracking-wide); padding: 7px 16px; border-radius: var(--radius-md); background: var(--accent-dim); border: 1px solid var(--accent); color: var(--accent-fg); cursor: pointer; transition: background var(--t-base), border-color var(--t-base); }
+  .migrate-btn:hover:not(:disabled) { background: var(--accent-muted); border-color: var(--accent-bright); }
+  .migrate-btn:disabled { opacity: 0.4; cursor: default; }
+
+  @keyframes fadeIn { from { opacity: 0 } to { opacity: 1 } }
+</style>

--- a/src/lib/components/tracking/TrackerImportModal.svelte
+++ b/src/lib/components/tracking/TrackerImportModal.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { X, CircleNotch, ArrowRight, Check, Warning, Sparkle, DownloadSimple, TrayArrowDown, ArrowsClockwise, Pause, Play, Trash, Books } from "phosphor-svelte";
+  import { X, CircleNotch, ArrowRight, Check, Warning, Sparkle, DownloadSimple, TrayArrowDown, ArrowsClockwise, Pause, Play, Trash, Books, FilmSlate } from "phosphor-svelte";
   import { tsunagu } from "$lib/server-adapters/tsunagu";
   import Thumbnail from "$lib/components/shared/manga/Thumbnail.svelte";
   import ExtensionIcon from "$lib/components/extensions/ExtensionIcon.svelte";
@@ -28,14 +28,7 @@
   const MATCH_THRESHOLD = 0.3;
   const GOOD_ENOUGH = 0.55;
 
-  const STATUSES = [
-    { key: "CURRENT", label: "Reading" },
-    { key: "PLANNING", label: "Planning" },
-    { key: "COMPLETED", label: "Completed" },
-    { key: "PAUSED", label: "On hold" },
-    { key: "DROPPED", label: "Dropped" },
-    { key: "REPEATING", label: "Rereading" },
-  ] as const;
+  const STATUS_KEYS = ["CURRENT", "PLANNING", "COMPLETED", "PAUSED", "DROPPED", "REPEATING"] as const;
 
   type Phase = "pick-target" | "matching" | "assign" | "importing" | "done";
   type EntryStatus = "pending" | "searching" | "found" | "no-match" | "already" | "skipped" | "imported" | "failed";
@@ -61,6 +54,7 @@
   interface CachePayload {
     v: number;
     trackerKey: string;
+    contentType?: ContentType;
     sourceId: string;
     statuses: string[];
     entries: Array<{
@@ -143,7 +137,8 @@
   }
 
   let phase: Phase = $state("pick-target");
-  let allSources: Source[] = $state([]);
+  let importKind: ContentType = $state("MANGA");
+  let installedSources: Source[] = $state([]);
   let loadingSources = $state(true);
   let targetSource: Source | null = $state(null);
   let selectedLang = $state("all");
@@ -168,6 +163,18 @@
   let importProgress = $state({ done: 0, total: 0, failed: 0 });
   let retryingIds = $state<string[]>([]);
 
+  const isAnime = $derived(importKind === "ANIME");
+  const progressWord = $derived(isAnime ? "ep." : "ch.");
+  const statusChips = $derived(STATUS_KEYS.map(key => ({
+    key,
+    label: key === "CURRENT" ? (isAnime ? "Watching" : "Reading")
+      : key === "REPEATING" ? (isAnime ? "Rewatching" : "Rereading")
+      : key === "PLANNING" ? "Planning"
+      : key === "COMPLETED" ? "Completed"
+      : key === "PAUSED" ? "On hold"
+      : "Dropped",
+  })));
+  const allSources = $derived(installedSources.filter(s => s.contentType === importKind));
   const availableLangs = $derived.by(() => {
     const langs = Array.from(new Set<string>(allSources.map(s => s.lang))).sort();
     const en = langs.indexOf("en");
@@ -209,16 +216,16 @@
     const prevAll = new Set(Object.values(ledger.lastSeen).flat());
     const hasHistory = ledger.lastFetchedAt > 0;
     const out: Record<string, { left: number; neu: number; total: number }> = {};
-    for (const s of STATUSES) {
-      const rows = listSnapshot.filter(e => (e.status || "").toUpperCase() === s.key);
+    for (const s of STATUS_KEYS) {
+      const rows = listSnapshot.filter(e => (e.status || "").toUpperCase() === s);
       const left = rows.filter(e => !pulledSet.has(e.remoteId)).length;
       const neu = hasHistory ? rows.filter(e => !prevAll.has(e.remoteId) && !pulledSet.has(e.remoteId)).length : 0;
-      out[s.key] = { left, neu, total: rows.length };
+      out[s] = { left, neu, total: rows.length };
     }
     return out;
   });
-  const leftoverTotal = $derived(STATUSES.reduce((n, s) => n + (statusCounts[s.key]?.left ?? 0), 0));
-  const newTotal = $derived(STATUSES.reduce((n, s) => n + (statusCounts[s.key]?.neu ?? 0), 0));
+  const leftoverTotal = $derived(STATUS_KEYS.reduce((n, s) => n + (statusCounts[s]?.left ?? 0), 0));
+  const newTotal = $derived(STATUS_KEYS.reduce((n, s) => n + (statusCounts[s]?.neu ?? 0), 0));
   const allMissingSelected = $derived(missingIds.length > 0 && missingIds.every(id => selectedIds.includes(id)));
   const selectedMissing = $derived(selectedIds.filter(id => missingIds.includes(id)).length);
   const assignRows = $derived.by(() => {
@@ -248,10 +255,18 @@
   }
 
   function cacheKey() {
-    return `moku:tracker-import:${trackerKey}`;
+    return `moku:tracker-import:${trackerKey}:${importKind}`;
   }
 
   function ledgerKey() {
+    return `moku:tracker-import-ledger:${trackerKey}:${importKind}`;
+  }
+
+  function legacyCacheKey() {
+    return `moku:tracker-import:${trackerKey}`;
+  }
+
+  function legacyLedgerKey() {
     return `moku:tracker-import-ledger:${trackerKey}`;
   }
 
@@ -292,6 +307,7 @@
     const payload: CachePayload = {
       v: CACHE_VER,
       trackerKey,
+      contentType: importKind,
       sourceId: targetSource?.id ?? "",
       statuses: [...selectedStatuses],
       entries: entries.map(e => ({
@@ -312,14 +328,18 @@
   }
 
   function clearCache() {
-    try { localStorage.removeItem(cacheKey()); } catch { /* ignore */ }
+    try {
+      localStorage.removeItem(cacheKey());
+      if (importKind === "MANGA") localStorage.removeItem(legacyCacheKey());
+    } catch { /* ignore */ }
     draft = null;
   }
 
   function readLedger(): ImportLedger {
     if (typeof localStorage === "undefined") return { ...EMPTY_LEDGER };
     try {
-      const raw = localStorage.getItem(ledgerKey());
+      const raw = localStorage.getItem(ledgerKey())
+        ?? (importKind === "MANGA" ? localStorage.getItem(legacyLedgerKey()) : null);
       if (!raw) return { ...EMPTY_LEDGER };
       const p = JSON.parse(raw) as ImportLedger;
       if (p.v !== LEDGER_VER) return { ...EMPTY_LEDGER };
@@ -371,22 +391,24 @@
   }
 
   async function refreshSnapshot() {
+    const kind = importKind;
     snapshotLoading = true;
     const run = (async () => {
       try {
         const [remote, local] = await Promise.all([
-          tsunagu.trackerLibrary(trackerKey, "MANGA" as ContentType, STATUSES.map(s => s.key)),
-          tsunagu.library("MANGA").catch(() => []),
+          tsunagu.trackerLibrary(trackerKey, kind, [...STATUS_KEYS]),
+          tsunagu.library(kind).catch(() => []),
         ]);
-        if (cancelled) return;
+        if (cancelled || importKind !== kind) return;
         listSnapshot = remote;
         snapshotAt = Date.now();
         pulledIds = local.flatMap(m => (m.trackLinks ?? []).filter(l => l.trackerKey === trackerKey).map(l => l.remoteId));
       } catch {
+        if (cancelled || importKind !== kind) return;
         listSnapshot = [];
         snapshotAt = 0;
       } finally {
-        snapshotLoading = false;
+        if (importKind === kind) snapshotLoading = false;
       }
     })();
     snapshotTask = run;
@@ -394,11 +416,12 @@
   }
 
   async function loadRemoteList(): Promise<{ rows: TrackerLibraryEntry[]; fromCache: boolean }> {
+    const kind = importKind;
     if (snapshotTask) await snapshotTask;
-    if (cancelled) return { rows: [], fromCache: true };
+    if (cancelled || importKind !== kind) return { rows: [], fromCache: true };
     if (snapshotIsFresh()) return { rows: snapshotForStatuses(selectedStatuses), fromCache: true };
-    const remote = await tsunagu.trackerLibrary(trackerKey, "MANGA" as ContentType, selectedStatuses);
-    if (cancelled) return { rows: remote, fromCache: false };
+    const remote = await tsunagu.trackerLibrary(trackerKey, kind, selectedStatuses);
+    if (cancelled || importKind !== kind) return { rows: remote, fromCache: false };
     mergeSnapshot(remote);
     return { rows: remote, fromCache: false };
   }
@@ -406,10 +429,12 @@
   function readCache(): CachePayload | null {
     if (typeof localStorage === "undefined") return null;
     try {
-      const raw = localStorage.getItem(cacheKey());
+      const raw = localStorage.getItem(cacheKey())
+        ?? (importKind === "MANGA" ? localStorage.getItem(legacyCacheKey()) : null);
       if (!raw) return null;
       const p = JSON.parse(raw) as CachePayload;
       if (p.v !== CACHE_VER || p.trackerKey !== trackerKey || !Array.isArray(p.entries) || p.entries.length === 0) return null;
+      if (p.contentType && p.contentType !== importKind) return null;
       return p;
     } catch {
       return null;
@@ -452,7 +477,7 @@
     halt = true;
     cancelled = true;
     persistCache();
-    if (listSnapshot.length) rememberSeen(listSnapshot, STATUSES.map(s => s.key));
+    if (listSnapshot.length) rememberSeen(listSnapshot, [...STATUS_KEYS]);
     persistLedger({ lastStatuses: [...selectedStatuses] });
     onClose();
   }
@@ -460,15 +485,10 @@
   $effect(() => {
     tsunagu.installedExtensions()
       .then(exts => {
-        allSources = exts
-          .filter(e => e.installed && e.contentType === "MANGA")
+        installedSources = exts
+          .filter(e => e.installed && (e.contentType === "MANGA" || e.contentType === "ANIME"))
           .map(toSource);
-        const prefLang = settingsState.settings.preferredExtensionLang ?? "";
-        const langs = new Set(allSources.map(s => s.lang));
-        if (prefLang && langs.has(prefLang) && langs.size > 1) selectedLang = prefLang;
-        draft = readCache();
-        ledger = readLedger();
-        if (!draft && ledger.lastStatuses.length) selectedStatuses = [...ledger.lastStatuses];
+        applyKindChrome();
         void refreshSnapshot();
       })
       .catch(console.error)
@@ -490,6 +510,29 @@
       selectedStatuses = [...selectedStatuses, key];
     }
     persistLedger({ lastStatuses: [...selectedStatuses] });
+  }
+
+  function applyKindChrome() {
+    const prefLang = settingsState.settings.preferredExtensionLang ?? "";
+    const langs = new Set(installedSources.filter(s => s.contentType === importKind).map(s => s.lang));
+    selectedLang = prefLang && langs.has(prefLang) && langs.size > 1 ? prefLang : "all";
+    targetSource = null;
+    massSourceId = "";
+    listSnapshot = [];
+    snapshotAt = 0;
+    pulledIds = [];
+    snapshotTask = null;
+    draft = readCache();
+    ledger = readLedger();
+    selectedStatuses = (!draft && ledger.lastStatuses.length) ? [...ledger.lastStatuses] : ["CURRENT"];
+    if (draft?.statuses.length) selectedStatuses = [...draft.statuses];
+  }
+
+  function setImportKind(kind: ContentType) {
+    if (kind === importKind || phase !== "pick-target") return;
+    importKind = kind;
+    applyKindChrome();
+    void refreshSnapshot();
   }
 
   function scrollLangStrip(dir: -1 | 1) {
@@ -560,7 +603,7 @@
     }
     if (cancelled || halt) return;
 
-    const local = await tsunagu.library("MANGA").catch(() => []);
+    const local = await tsunagu.library(importKind).catch(() => []);
     const alreadyByRemote = new Set(
       local.flatMap(m => (m.trackLinks ?? []).filter(l => l.trackerKey === trackerKey).map(l => l.remoteId)),
     );
@@ -612,7 +655,7 @@
     }
     if (cancelled || halt) return;
 
-    const local = await tsunagu.library("MANGA").catch(() => []);
+    const local = await tsunagu.library(importKind).catch(() => []);
     const alreadyByRemote = new Set(
       local.flatMap(m => (m.trackLinks ?? []).filter(l => l.trackerKey === trackerKey).map(l => l.remoteId)),
     );
@@ -759,7 +802,7 @@
       await tsunagu.createTrackerStub(
         trackerKey,
         entry.remote.remoteId,
-        "MANGA",
+        importKind,
         displayTitle(entry.remote),
         entry.remote.coverUrl,
       );
@@ -886,7 +929,7 @@
     const blob = new Blob([JSON.stringify(rows, null, 2)], { type: "application/json" });
     const a = document.createElement("a");
     a.href = URL.createObjectURL(blob);
-    a.download = `anilist-import-${trackerKey}-failed.json`;
+    a.download = `anilist-import-${trackerKey}-${importKind}-failed.json`;
     a.click();
     URL.revokeObjectURL(a.href);
   }
@@ -905,7 +948,7 @@
         <div class="source-context-info">
           <span class="modal-eyebrow">Library import</span>
           <span class="modal-title">Import from {trackerName}</span>
-          <span class="modal-sub">Manga only · library without a source, or match titles on one source</span>
+          <span class="modal-sub">Library without a source, or match titles on one source</span>
         </div>
       </div>
       {#if phase !== "importing"}
@@ -920,7 +963,7 @@
           <div class="resume-banner">
             <div class="resume-copy">
               <span class="resume-title">Resume import</span>
-              <span class="resume-sub">{draftSourceName()} · {draft.searchDone} / {draft.searchTotal} searched</span>
+              <span class="resume-sub">{isAnime ? "Anime" : "Manga"} · {draftSourceName()} · {draft.searchDone} / {draft.searchTotal} searched</span>
             </div>
             <button class="back-btn" onclick={clearCache}><Trash size={12} weight="light" /> Discard</button>
             <button class="migrate-btn" onclick={() => void resumeFromDraft()}>
@@ -929,10 +972,17 @@
           </div>
         {/if}
         <div class="phase-label-row">
+          <span class="phase-label">Type</span>
+        </div>
+        <div class="status-chips">
+          <button class="status-chip" class:status-chip-active={importKind === "MANGA"} onclick={() => setImportKind("MANGA")}>Manga</button>
+          <button class="status-chip" class:status-chip-active={importKind === "ANIME"} onclick={() => setImportKind("ANIME")}>Anime</button>
+        </div>
+        <div class="phase-label-row">
           <span class="phase-label">List statuses</span>
         </div>
         <div class="status-chips">
-          {#each STATUSES as s}
+          {#each statusChips as s}
             <button
               class="status-chip"
               class:status-chip-active={selectedStatuses.includes(s.key)}
@@ -960,7 +1010,7 @@
         {/if}
         <p class="rate-note">
           <Warning size={12} weight="bold" />
-          AniList rate-limits bulk imports. Matching on a source is slower. Skip MangaDex for a full list.
+          AniList rate-limits bulk imports. Matching on a source is slower.{importKind === "MANGA" ? " Skip MangaDex for a full list." : ""}
         </p>
 
         <div class="phase-label-row">
@@ -969,7 +1019,11 @@
         <div class="source-list source-list-tight">
           <button class="source-row source-row-library" onclick={() => void startStubImport()}>
             <div class="source-icon-wrap logo">
-              <Books size={18} weight="light" />
+              {#if isAnime}
+                <FilmSlate size={18} weight="light" />
+              {:else}
+                <Books size={18} weight="light" />
+              {/if}
             </div>
             <div class="source-info">
               <span class="source-name">Library only · no source</span>
@@ -985,7 +1039,7 @@
         {#if loadingSources}
           <div class="centered"><CircleNotch size={16} weight="light" class="anim-spin" style="color:var(--text-faint)" /></div>
         {:else if allSources.length === 0}
-          <div class="centered"><span class="hint">Install a manga source to match covers and chapters.</span></div>
+          <div class="centered"><span class="hint">Install {isAnime ? "an anime" : "a manga"} source to match titles.</span></div>
         {:else}
           {#if hasMultipleLangs}
             <div class="src-lang-bar">
@@ -1035,7 +1089,11 @@
             {:else if stubImport}
               <div class="review-source">
                 <div class="source-icon-wrap small logo">
-                  <Books size={12} weight="light" />
+                  {#if isAnime}
+                    <FilmSlate size={12} weight="light" />
+                  {:else}
+                    <Books size={12} weight="light" />
+                  {/if}
                 </div>
                 <span class="review-source-name">Library only</span>
               </div>
@@ -1090,10 +1148,10 @@
                     <Sparkle size={9} weight="fill" style="color:var(--accent-fg);flex-shrink:0" />
                     {entry.match.title}
                     <span class="entry-sim">{Math.round(entry.similarity * 100)}%</span>
-                    <span class="entry-prog">ch. {entry.remote.progress}</span>
+                    <span class="entry-prog">{progressWord} {entry.remote.progress}</span>
                   </span>
                 {:else if entry.status === "found"}
-                  <span class="entry-match">Library stub · ch. {entry.remote.progress}</span>
+                  <span class="entry-match">Library stub · {progressWord} {entry.remote.progress}</span>
                 {:else if entry.status === "no-match"}
                   <span class="entry-no-match">No match found</span>
                 {:else if entry.status === "already"}
@@ -1107,7 +1165,7 @@
                 {:else if entry.status === "failed"}
                   <span class="entry-fail">{entry.error ?? "Failed"}</span>
                 {:else if !displaySub(entry.remote)}
-                  <span class="entry-searching">{entry.remote.status} · ch. {entry.remote.progress}</span>
+                  <span class="entry-searching">{entry.remote.status} · {progressWord} {entry.remote.progress}</span>
                 {/if}
               </div>
               <div class="entry-status">
@@ -1178,7 +1236,7 @@
               <tr>
                 <th class="col-check"></th>
                 <th class="col-title">Title</th>
-                <th class="col-prog">Ch.</th>
+                <th class="col-prog">{isAnime ? "Ep." : "Ch."}</th>
                 {#if !stubImport}<th class="col-src">Source</th>{/if}
                 <th class="col-stat">{stubImport ? "Status" : "Match"}</th>
               </tr>

--- a/src/lib/components/tracking/TrackerImportModal.svelte
+++ b/src/lib/components/tracking/TrackerImportModal.svelte
@@ -143,6 +143,7 @@
   let targetSource: Source | null = $state(null);
   let selectedLang = $state("all");
   let langStripEl: HTMLDivElement | undefined = $state();
+  let langStripOverflow = $state(false);
   let selectedStatuses = $state<string[]>(["CURRENT"]);
   let dryRun = $state(false);
   let stubImport = $state(false);
@@ -182,6 +183,22 @@
     return langs;
   });
   const hasMultipleLangs = $derived(availableLangs.length > 1);
+
+  $effect(() => {
+    const el = langStripEl;
+    void availableLangs.length;
+    if (!el) {
+      langStripOverflow = false;
+      return;
+    }
+    const measure = () => {
+      langStripOverflow = el.scrollWidth > el.clientWidth + 1;
+    };
+    measure();
+    const ro = new ResizeObserver(measure);
+    ro.observe(el);
+    return () => ro.disconnect();
+  });
   const visibleSources = $derived.by(() => {
     if (selectedLang !== "all") return allSources.filter(s => s.lang === selectedLang);
     const map = new Map<string, Source>();
@@ -948,7 +965,10 @@
         <div class="source-context-info">
           <span class="modal-eyebrow">Library import</span>
           <span class="modal-title">Import from {trackerName}</span>
-          <span class="modal-sub">Library without a source, or match titles on one source</span>
+          <span class="modal-sub">
+            <Warning size={12} weight="bold" />
+            AniList rate-limits bulk imports, so matching on a source will be slower
+          </span>
         </div>
       </div>
       {#if phase !== "importing"}
@@ -959,117 +979,123 @@
     <div class="body">
 
       {#if phase === "pick-target"}
-        {#if draft}
-          <div class="resume-banner">
-            <div class="resume-copy">
-              <span class="resume-title">Resume import</span>
-              <span class="resume-sub">{isAnime ? "Anime" : "Manga"} · {draftSourceName()} · {draft.searchDone} / {draft.searchTotal} searched</span>
-            </div>
-            <button class="back-btn" onclick={clearCache}><Trash size={12} weight="light" /> Discard</button>
-            <button class="migrate-btn" onclick={() => void resumeFromDraft()}>
-              <Play size={12} weight="bold" /> Resume
-            </button>
-          </div>
-        {/if}
-        <div class="phase-label-row">
-          <span class="phase-label">Type</span>
-        </div>
-        <div class="status-chips">
-          <button class="status-chip" class:status-chip-active={importKind === "MANGA"} onclick={() => setImportKind("MANGA")}>Manga</button>
-          <button class="status-chip" class:status-chip-active={importKind === "ANIME"} onclick={() => setImportKind("ANIME")}>Anime</button>
-        </div>
-        <div class="phase-label-row">
-          <span class="phase-label">List statuses</span>
-        </div>
-        <div class="status-chips">
-          {#each statusChips as s}
-            <button
-              class="status-chip"
-              class:status-chip-active={selectedStatuses.includes(s.key)}
-              onclick={() => toggleStatus(s.key)}
-            >
-              {s.label}
-              {#if statusCounts[s.key]?.neu}
-                <span class="chip-badge chip-badge-new">{statusCounts[s.key].left} · {statusCounts[s.key].neu} new</span>
-              {:else if statusCounts[s.key]?.left}
-                <span class="chip-badge">{statusCounts[s.key].left}</span>
-              {/if}
-            </button>
-          {/each}
-        </div>
-        {#if snapshotLoading}
-          <p class="list-hint">Checking AniList lists…</p>
-        {:else if listSnapshot.length > 0}
-          <p class="list-hint">
-            {leftoverTotal} not in library
-            {#if newTotal > 0} · {newTotal} new on AniList{/if}
-            {#if ledger.lastFetchedAt}
-              · last sync {new Date(ledger.lastFetchedAt).toLocaleDateString()}
-            {/if}
-          </p>
-        {/if}
-        <p class="rate-note">
-          <Warning size={12} weight="bold" />
-          AniList rate-limits bulk imports. Matching on a source is slower.{importKind === "MANGA" ? " Skip MangaDex for a full list." : ""}
-        </p>
-
-        <div class="phase-label-row">
-          <span class="phase-label">Import into library</span>
-        </div>
-        <div class="source-list source-list-tight">
-          <button class="source-row source-row-library" onclick={() => void startStubImport()}>
-            <div class="source-icon-wrap logo">
-              {#if isAnime}
-                <FilmSlate size={18} weight="light" />
-              {:else}
-                <Books size={18} weight="light" />
-              {/if}
-            </div>
-            <div class="source-info">
-              <span class="source-name">Library only · no source</span>
-              <span class="source-meta">Titles and AniList tracking. Assign a source later.</span>
-            </div>
-            <ArrowRight size={13} weight="light" class="source-arrow" />
-          </button>
-        </div>
-
-        <div class="phase-label-row">
-          <span class="phase-label">Or match on a source</span>
-        </div>
-        {#if loadingSources}
-          <div class="centered"><CircleNotch size={16} weight="light" class="anim-spin" style="color:var(--text-faint)" /></div>
-        {:else if allSources.length === 0}
-          <div class="centered"><span class="hint">Install {isAnime ? "an anime" : "a manga"} source to match titles.</span></div>
-        {:else}
-          {#if hasMultipleLangs}
-            <div class="src-lang-bar">
-              <button class="src-lang-nav" onclick={() => scrollLangStrip(-1)}>‹</button>
-              <div class="src-lang-chips" bind:this={langStripEl}>
-                <button class="src-lang-chip" class:src-lang-chip-active={selectedLang === "all"} onclick={() => selectedLang = "all"}>All</button>
-                {#each availableLangs as lang}
-                  <button class="src-lang-chip" class:src-lang-chip-active={selectedLang === lang} onclick={() => selectedLang = lang}>
-                    {lang.toUpperCase()}
-                  </button>
-                {/each}
+        <div class="pick">
+          {#if draft}
+            <div class="resume-banner">
+              <div class="resume-copy">
+                <span class="resume-title">Resume import</span>
+                <span class="resume-sub">{isAnime ? "Anime" : "Manga"} · {draftSourceName()} · {draft.searchDone} / {draft.searchTotal} searched</span>
               </div>
-              <button class="src-lang-nav" onclick={() => scrollLangStrip(1)}>›</button>
+              <button class="back-btn" onclick={clearCache}><Trash size={12} weight="light" /> Discard</button>
+              <button class="migrate-btn" onclick={() => void resumeFromDraft()}>
+                <Play size={12} weight="bold" /> Resume
+              </button>
             </div>
           {/if}
-          <div class="source-list">
-            {#each visibleSources as src}
-              <button class="source-row" onclick={() => startSearch(src)}>
-                <div class="source-icon-wrap">
-                  <ExtensionIcon src={src.iconUrl} alt={src.name} class="source-icon" size={36} />
+          <div class="pick-chrome">
+            <div class="phase-label-row">
+              <span class="phase-label">Type</span>
+            </div>
+            <div class="status-chips">
+              <button class="status-chip" class:status-chip-active={importKind === "MANGA"} onclick={() => setImportKind("MANGA")}>Manga</button>
+              <button class="status-chip" class:status-chip-active={importKind === "ANIME"} onclick={() => setImportKind("ANIME")}>Anime</button>
+            </div>
+            <div class="phase-label-row">
+              <span class="phase-label">List statuses</span>
+            </div>
+            <div class="status-chips">
+              {#each statusChips as s}
+                <button
+                  class="status-chip"
+                  class:status-chip-active={selectedStatuses.includes(s.key)}
+                  onclick={() => toggleStatus(s.key)}
+                >
+                  {s.label}
+                  {#if statusCounts[s.key]?.neu}
+                    <span class="chip-badge chip-badge-new">{statusCounts[s.key].left} · {statusCounts[s.key].neu} new</span>
+                  {:else if statusCounts[s.key]?.left}
+                    <span class="chip-badge">{statusCounts[s.key].left}</span>
+                  {/if}
+                </button>
+              {/each}
+            </div>
+            {#if snapshotLoading}
+              <p class="list-hint">Checking AniList lists…</p>
+            {:else if listSnapshot.length > 0}
+              <p class="list-hint">
+                {leftoverTotal} not in library
+                {#if newTotal > 0} · {newTotal} new on AniList{/if}
+                {#if ledger.lastFetchedAt}
+                  · last sync {new Date(ledger.lastFetchedAt).toLocaleDateString()}
+                {/if}
+              </p>
+            {/if}
+
+            <div class="phase-label-row">
+              <span class="phase-label">Import into library</span>
+            </div>
+            <div class="source-list source-list-tight">
+              <button class="source-row source-row-library" onclick={() => void startStubImport()}>
+                <div class="source-icon-wrap logo">
+                  {#if isAnime}
+                    <FilmSlate size={18} weight="light" />
+                  {:else}
+                    <Books size={18} weight="light" />
+                  {/if}
                 </div>
                 <div class="source-info">
-                  <span class="source-name">{src.displayName}</span>
-                  <span class="source-meta">{src.lang.toUpperCase()}{src.isNsfw ? " · NSFW" : ""}</span>
+                  <span class="source-name">Library only · no source</span>
+                  <span class="source-meta">Titles and AniList trackin (assign a source later)</span>
                 </div>
                 <ArrowRight size={13} weight="light" class="source-arrow" />
               </button>
-            {/each}
+            </div>
           </div>
-        {/if}
+
+          <div class="pick-sources">
+            <div class="phase-label-row">
+              <span class="phase-label">Or match on a source</span>
+            </div>
+            {#if loadingSources}
+              <div class="centered"><CircleNotch size={16} weight="light" class="anim-spin" style="color:var(--text-faint)" /></div>
+            {:else if allSources.length === 0}
+              <div class="centered"><span class="hint">Install {isAnime ? "an anime" : "a manga"} source to match titles.</span></div>
+            {:else}
+              {#if hasMultipleLangs}
+                <div class="src-lang-bar">
+                  {#if langStripOverflow}
+                    <button class="src-lang-nav" onclick={() => scrollLangStrip(-1)}>‹</button>
+                  {/if}
+                  <div class="src-lang-chips" bind:this={langStripEl}>
+                    <button class="src-lang-chip" class:src-lang-chip-active={selectedLang === "all"} onclick={() => selectedLang = "all"}>All</button>
+                    {#each availableLangs as lang}
+                      <button class="src-lang-chip" class:src-lang-chip-active={selectedLang === lang} onclick={() => selectedLang = lang}>
+                        {lang.toUpperCase()}
+                      </button>
+                    {/each}
+                  </div>
+                  {#if langStripOverflow}
+                    <button class="src-lang-nav" onclick={() => scrollLangStrip(1)}>›</button>
+                  {/if}
+                </div>
+              {/if}
+              <div class="source-list">
+                {#each visibleSources as src}
+                  <button class="source-row" onclick={() => startSearch(src)}>
+                    <div class="source-icon-wrap">
+                      <ExtensionIcon src={src.iconUrl} alt={src.name} class="source-icon" size={36} />
+                    </div>
+                    <div class="source-info">
+                      <span class="source-name">{src.displayName}</span>
+                      <span class="source-meta">{src.lang.toUpperCase()}{src.isNsfw ? " · NSFW" : ""}</span>
+                    </div>
+                    <ArrowRight size={13} weight="light" class="source-arrow" />
+                  </button>
+                {/each}
+              </div>
+            {/if}
+          </div>
+        </div>
 
       {:else if phase === "matching" || phase === "importing"}
         <div class="review-header">
@@ -1383,8 +1409,8 @@
 </div>
 
 <style>
-  .overlay { position: fixed; inset: 0; padding: 24px; background: rgba(0,0,0,0.6); display: flex; align-items: center; justify-content: center; z-index: calc(var(--z-settings) + 2); animation: fadeIn 0.1s ease both; overflow: hidden; }
-  .modal { background: var(--bg-base); border: 1px solid var(--border-base); border-radius: var(--radius-xl); width: 560px; max-height: 100%; min-height: 0; display: flex; flex-direction: column; overflow: hidden; box-shadow: 0 8px 40px rgba(0,0,0,0.5); }
+  .overlay { position: fixed; inset: 0; padding: 24px; background: rgba(0,0,0,0.6); display: flex; align-items: center; justify-content: center; z-index: calc(var(--z-settings) + 2); animation: fadeIn 0.1s ease both; }
+  .modal { background: var(--bg-base); border: 1px solid var(--border-base); border-radius: var(--radius-xl); width: 560px; max-height: calc(100vh - 48px); min-height: 0; display: flex; flex-direction: column; overflow: hidden; box-shadow: 0 8px 40px rgba(0,0,0,0.5); }
   .modal-wide { width: min(860px, 100%); }
   .modal-fill { align-self: stretch; }
 
@@ -1397,15 +1423,24 @@
   .source-context-info { display: flex; flex-direction: column; gap: 2px; min-width: 0; }
   .modal-eyebrow { font-family: var(--font-ui); font-size: var(--text-2xs); color: var(--text-faint); letter-spacing: var(--tracking-wider); text-transform: uppercase; }
   .modal-title { font-size: var(--text-base); font-weight: var(--weight-medium); color: var(--text-primary); letter-spacing: var(--tracking-tight); }
-  .modal-sub { font-family: var(--font-ui); font-size: var(--text-2xs); color: var(--text-faint); letter-spacing: var(--tracking-wide); }
+  .modal-sub {
+    display: flex; align-items: flex-start; gap: 6px;
+    font-family: var(--font-ui); font-size: var(--text-2xs); color: var(--text-muted);
+    letter-spacing: var(--tracking-wide); line-height: 1.4;
+  }
+  .modal-sub :global(svg) { flex-shrink: 0; margin-top: 1px; color: var(--text-faint); }
   .close-btn { display: flex; align-items: center; justify-content: center; width: 24px; height: 24px; border-radius: var(--radius-md); color: var(--text-faint); background: none; border: none; cursor: pointer; transition: color var(--t-base), background var(--t-base); flex-shrink: 0; margin-top: 2px; }
   .close-btn:hover { color: var(--text-muted); background: var(--bg-raised); }
 
   .body { flex: 1; overflow: hidden; display: flex; flex-direction: column; min-height: 0; }
 
+  .pick { flex: 1; min-height: 0; display: flex; flex-direction: column; overflow-y: auto; --source-row-h: calc(36px + 16px); }
+  .pick-chrome { flex: 0 0 auto; }
+  .pick-sources { flex: 1 1 auto; min-height: calc(4 * var(--source-row-h)); display: flex; flex-direction: column; }
+
   .phase-label-row { padding: var(--sp-3) var(--sp-4) var(--sp-2); flex-shrink: 0; }
   .phase-label { font-family: var(--font-ui); font-size: var(--text-2xs); color: var(--text-faint); letter-spacing: var(--tracking-widest); text-transform: uppercase; }
-  .centered { flex: 1; display: flex; align-items: center; justify-content: center; padding: var(--sp-8); }
+  .centered { flex: 1; min-height: calc(4 * var(--source-row-h)); display: flex; align-items: center; justify-content: center; padding: var(--sp-8); }
   .hint { font-family: var(--font-ui); font-size: var(--text-xs); color: var(--text-faint); letter-spacing: var(--tracking-wide); }
 
   .status-chips { display: flex; flex-wrap: wrap; gap: var(--sp-1); padding: 0 var(--sp-4) var(--sp-2); flex-shrink: 0; }
@@ -1415,13 +1450,6 @@
   .chip-badge { font-size: 9px; letter-spacing: var(--tracking-wide); padding: 0 5px; border-radius: var(--radius-sm); border: 1px solid var(--border-dim); color: var(--text-faint); }
   .chip-badge-new { color: var(--accent-fg); border-color: var(--accent-dim); background: var(--accent-muted); }
   .list-hint { margin: 0; padding: 0 var(--sp-4) var(--sp-2); font-family: var(--font-ui); font-size: var(--text-2xs); color: var(--text-faint); letter-spacing: var(--tracking-wide); }
-  .rate-note {
-    margin: 0; padding: 0 var(--sp-4) var(--sp-3);
-    display: flex; align-items: flex-start; gap: 6px;
-    font-family: var(--font-ui); font-size: var(--text-2xs); color: var(--text-muted); letter-spacing: var(--tracking-wide);
-    line-height: 1.4;
-  }
-  .rate-note :global(svg) { flex-shrink: 0; margin-top: 1px; color: var(--text-faint); }
 
   .src-lang-bar { display: flex; align-items: center; gap: var(--sp-1); padding: var(--sp-2); border-bottom: 1px solid var(--border-dim); flex-shrink: 0; }
   .src-lang-nav { display: flex; align-items: center; justify-content: center; width: 22px; height: 22px; flex-shrink: 0; border-radius: var(--radius-sm); border: 1px solid var(--border-dim); background: none; color: var(--text-faint); font-size: 15px; line-height: 1; cursor: pointer; transition: color var(--t-base), background var(--t-base); }
@@ -1432,8 +1460,8 @@
   .src-lang-chip:hover { color: var(--text-muted); background: var(--bg-raised); }
   .src-lang-chip-active { color: var(--accent-fg); border-color: var(--accent-dim); background: var(--accent-muted); }
 
-  .source-list { flex: 1; overflow-y: auto; padding: var(--sp-2); display: flex; flex-direction: column; gap: 1px; }
-  .source-list-tight { flex: 0 0 auto; padding-bottom: 0; }
+  .source-list { flex: 1; min-height: calc(4 * var(--source-row-h)); overflow-y: auto; padding: var(--sp-2); display: flex; flex-direction: column; gap: 1px; }
+  .source-list-tight { flex: 0 0 auto; min-height: 0; padding-bottom: 0; }
   .source-row { display: flex; align-items: center; gap: var(--sp-3); padding: 8px var(--sp-3); border-radius: var(--radius-md); border: 1px solid transparent; background: none; text-align: left; width: 100%; cursor: pointer; transition: background var(--t-fast), border-color var(--t-fast); }
   .source-row:hover { background: var(--bg-raised); border-color: var(--border-dim); }
   .source-row-library { border-color: var(--border-dim); }
@@ -1454,7 +1482,14 @@
   .stop-btn { display: flex; align-items: center; gap: 4px; font-family: var(--font-ui); font-size: var(--text-2xs); letter-spacing: var(--tracking-wide); padding: 3px 8px; border-radius: var(--radius-sm); background: none; color: var(--text-muted); border: 1px solid var(--border-dim); cursor: pointer; flex-shrink: 0; }
   .stop-btn:hover { color: var(--color-error); border-color: var(--color-error); background: var(--bg-raised); }
 
-  .resume-banner { display: flex; align-items: center; gap: var(--sp-2); margin: var(--sp-3) var(--sp-4) 0; padding: var(--sp-3); border: 1px solid var(--accent-dim); background: var(--accent-muted); border-radius: var(--radius-md); flex-shrink: 0; }
+  .resume-banner {
+    position: sticky; top: 0; z-index: 2;
+    display: flex; align-items: center; gap: var(--sp-2);
+    margin: 0; padding: var(--sp-3) var(--sp-4);
+    border-bottom: 1px solid var(--accent-dim);
+    background: var(--accent-muted);
+    flex-shrink: 0;
+  }
   .resume-copy { flex: 1; display: flex; flex-direction: column; gap: 2px; min-width: 0; }
   .resume-title { font-size: var(--text-sm); font-weight: var(--weight-medium); color: var(--text-primary); }
   .resume-sub { font-family: var(--font-ui); font-size: var(--text-2xs); color: var(--text-faint); letter-spacing: var(--tracking-wide); }

--- a/src/lib/components/tracking/TrackerImportModal.svelte
+++ b/src/lib/components/tracking/TrackerImportModal.svelte
@@ -979,19 +979,19 @@
     <div class="body">
 
       {#if phase === "pick-target"}
-        <div class="pick">
-          {#if draft}
-            <div class="resume-banner">
-              <div class="resume-copy">
-                <span class="resume-title">Resume import</span>
-                <span class="resume-sub">{isAnime ? "Anime" : "Manga"} · {draftSourceName()} · {draft.searchDone} / {draft.searchTotal} searched</span>
-              </div>
-              <button class="back-btn" onclick={clearCache}><Trash size={12} weight="light" /> Discard</button>
-              <button class="migrate-btn" onclick={() => void resumeFromDraft()}>
-                <Play size={12} weight="bold" /> Resume
-              </button>
+        {#if draft}
+          <div class="resume-banner">
+            <div class="resume-copy">
+              <span class="resume-title">Resume import</span>
+              <span class="resume-sub">{isAnime ? "Anime" : "Manga"} · {draftSourceName()} · {draft.searchDone} / {draft.searchTotal} searched</span>
             </div>
-          {/if}
+            <button class="back-btn" onclick={clearCache}><Trash size={12} weight="light" /> Discard</button>
+            <button class="migrate-btn" onclick={() => void resumeFromDraft()}>
+              <Play size={12} weight="bold" /> Resume
+            </button>
+          </div>
+        {/if}
+        <div class="pick">
           <div class="pick-chrome">
             <div class="phase-label-row">
               <span class="phase-label">Type</span>
@@ -1483,9 +1483,8 @@
   .stop-btn:hover { color: var(--color-error); border-color: var(--color-error); background: var(--bg-raised); }
 
   .resume-banner {
-    position: sticky; top: 0; z-index: 2;
     display: flex; align-items: center; gap: var(--sp-2);
-    margin: 0; padding: var(--sp-3) var(--sp-4);
+    padding: var(--sp-3) var(--sp-4);
     border-bottom: 1px solid var(--accent-dim);
     background: var(--accent-muted);
     flex-shrink: 0;

--- a/src/lib/components/tracking/TrackerImportModal.svelte
+++ b/src/lib/components/tracking/TrackerImportModal.svelte
@@ -21,7 +21,9 @@
   }
   let { trackerKey, trackerName, username = null, onClose, onDone }: Props = $props();
 
-  const SEARCH_GAP_MS = 1000;
+  const SEARCH_GAP_MS = 2000;
+  const SEARCH_QUERY_GAP_MS = 500;
+  const ANILIST_GAP_MS = 1200;
   const MATCH_THRESHOLD = 0.3;
   const GOOD_ENOUGH = 0.55;
 
@@ -238,7 +240,7 @@
   }
 
   function sourceLabel(src: Source): string {
-    return `${src.displayName} (${src.lang.toUpperCase()})`;
+    return src.displayName;
   }
 
   function cacheKey() {
@@ -473,7 +475,10 @@
   async function matchOnSource(source: Source, remote: TrackerLibraryEntry): Promise<Pick<EntryResult, "match" | "similarity" | "status" | "error">> {
     let best: { manga: Manga; similarity: number } | null = null;
     try {
-      for (const q of searchQueries(remote)) {
+      const queries = searchQueries(remote);
+      for (let qi = 0; qi < queries.length; qi++) {
+        const q = queries[qi];
+        if (qi > 0) await sleep(SEARCH_QUERY_GAP_MS);
         const resp = await tsunagu.search(source.id, q, 1);
         for (const r of resp.results) {
           const similarity = scoreHit(remote, r.title);
@@ -660,14 +665,15 @@
       try {
         await tsunagu.applyMetadataMatch(info.id, entry.remote.remoteId, "anilist");
       } catch { /* metadata is optional; tracking still binds */ }
+      await sleep(ANILIST_GAP_MS);
     }
     const link = await tsunagu.bindTrack(info.id, trackerKey, entry.remote.remoteId);
+    await sleep(ANILIST_GAP_MS);
     await tsunagu.updateTrack(link.id, {
       status: alStatusToTrack(entry.remote.status),
       score: entry.remote.score,
       lastChapterRead: entry.remote.progress,
     });
-    await tsunagu.pullTracker(info.id).catch(() => {});
     if (!pulledIds.includes(entry.remote.remoteId)) pulledIds = [...pulledIds, entry.remote.remoteId];
   }
 
@@ -728,6 +734,7 @@
         importProgress = { ...importProgress, done: importProgress.done + 1, failed: importProgress.failed + 1 };
       }
       persistCache();
+      if (!dryRun) await sleep(ANILIST_GAP_MS);
     }
 
     if (!dryRun) {
@@ -849,6 +856,10 @@
             {/if}
           </p>
         {/if}
+        <p class="rate-note">
+          <Warning size={12} weight="bold" />
+          AniList and sources rate-limit bulk imports. Wait a few minutes between runs. Skip MangaDex for a full list.
+        </p>
 
         <div class="phase-label-row">
           <span class="phase-label">Default destination source</span>
@@ -1210,6 +1221,13 @@
   .chip-badge { font-size: 9px; letter-spacing: var(--tracking-wide); padding: 0 5px; border-radius: var(--radius-sm); border: 1px solid var(--border-dim); color: var(--text-faint); }
   .chip-badge-new { color: var(--accent-fg); border-color: var(--accent-dim); background: var(--accent-muted); }
   .list-hint { margin: 0; padding: 0 var(--sp-4) var(--sp-2); font-family: var(--font-ui); font-size: var(--text-2xs); color: var(--text-faint); letter-spacing: var(--tracking-wide); }
+  .rate-note {
+    margin: 0; padding: 0 var(--sp-4) var(--sp-3);
+    display: flex; align-items: flex-start; gap: 6px;
+    font-family: var(--font-ui); font-size: var(--text-2xs); color: var(--text-muted); letter-spacing: var(--tracking-wide);
+    line-height: 1.4;
+  }
+  .rate-note :global(svg) { flex-shrink: 0; margin-top: 1px; color: var(--text-faint); }
 
   .src-lang-bar { display: flex; align-items: center; gap: var(--sp-1); padding: var(--sp-2); border-bottom: 1px solid var(--border-dim); flex-shrink: 0; }
   .src-lang-nav { display: flex; align-items: center; justify-content: center; width: 22px; height: 22px; flex-shrink: 0; border-radius: var(--radius-sm); border: 1px solid var(--border-dim); background: none; color: var(--text-faint); font-size: 15px; line-height: 1; cursor: pointer; transition: color var(--t-base), background var(--t-base); }
@@ -1282,8 +1300,16 @@
   .mass-search-btn { padding: 5px 12px; }
   .src-select {
     font-family: var(--font-ui); font-size: var(--text-2xs); letter-spacing: var(--tracking-wide);
-    color: var(--text-secondary); background: var(--bg-raised); border: 1px solid var(--border-dim);
-    border-radius: var(--radius-sm); padding: 4px 8px; min-width: 0; max-width: 220px; cursor: pointer;
+    color: var(--text-secondary);
+    background-color: var(--bg-raised);
+    border: 1px solid var(--border-dim);
+    border-radius: var(--radius-sm);
+    padding: 4px 22px 4px 8px;
+    min-width: 0; max-width: 220px; cursor: pointer;
+    appearance: none; -webkit-appearance: none;
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='8' height='5' viewBox='0 0 8 5'%3E%3Cpath d='M1 1l3 3 3-3' stroke='%236e6c68' stroke-width='1.3' fill='none' stroke-linecap='round'/%3E%3C/svg%3E");
+    background-repeat: no-repeat;
+    background-position: right 8px center;
   }
   .src-select:focus { outline: none; border-color: var(--accent-dim); }
   .src-select:disabled { opacity: 0.5; cursor: default; }

--- a/src/lib/core/sourceErrors.ts
+++ b/src/lib/core/sourceErrors.ts
@@ -28,9 +28,38 @@ const LABELS: Record<SourceErrorCode, { label: string; retriable: boolean; expec
 	INTERNAL:            { label: 'Something went wrong',     retriable: true,  expected: false },
 }
 
+function errorText(e: unknown): string {
+	if (typeof e === 'string') return e
+	if (e instanceof Error) return e.message
+	return ''
+}
+
+function isTimeout(e: unknown): boolean {
+	const grpc = e instanceof GraphQLError ? e.grpc : ''
+	if (grpc === 'DeadlineExceeded' || grpc === 'Canceled') return true
+	return /DeadlineExceeded|deadline exceeded/i.test(errorText(e))
+}
+
 export function sourceErrorCode(e: unknown): SourceErrorCode | null {
-	const raw = e instanceof GraphQLError ? e.code : undefined
-	if (raw && raw in LABELS) return raw as SourceErrorCode
+	if (e instanceof GraphQLError) {
+		const raw = e.code
+		if (raw && raw in LABELS) return raw as SourceErrorCode
+		if (e.grpc === 'DeadlineExceeded' || e.grpc === 'Canceled') return 'SOURCE_NETWORK'
+		if (e.grpc === 'Unavailable') return 'SOURCE_UNAVAILABLE'
+		if (e.grpc === 'NotFound') return 'SOURCE_NOT_FOUND'
+		if (e.grpc === 'ResourceExhausted') return 'SOURCE_RATE_LIMITED'
+		if (e.grpc === 'FailedPrecondition') return 'SOURCE_CLOUDFLARE'
+		if (e.grpc === 'DataLoss') return 'SOURCE_PARSE'
+	}
+	const msg = errorText(e)
+	if (!msg) return null
+	if (isTimeout(e)) return 'SOURCE_NETWORK'
+	if (/SOURCE_CLOUDFLARE|cloudflare/i.test(msg)) return 'SOURCE_CLOUDFLARE'
+	if (/SOURCE_RATE_LIMITED|ResourceExhausted|rate.?limit/i.test(msg)) return 'SOURCE_RATE_LIMITED'
+	if (/SOURCE_NOT_FOUND/i.test(msg)) return 'SOURCE_NOT_FOUND'
+	if (/SOURCE_UNAVAILABLE|code = Unavailable/i.test(msg)) return 'SOURCE_UNAVAILABLE'
+	if (/SOURCE_PARSE|DataLoss/i.test(msg)) return 'SOURCE_PARSE'
+	if (/rpc error|resolveMedia|get details for|input:\d+:/i.test(msg)) return 'INTERNAL'
 	return null
 }
 
@@ -40,12 +69,16 @@ export function sourceErrorInfo(e: unknown): SourceErrorInfo | null {
 	const meta = LABELS[code]
 	return {
 		code,
-		label: meta.label,
-		message: e instanceof Error ? e.message : meta.label,
+		label: isTimeout(e) ? 'Source timed out' : meta.label,
+		message: errorText(e) || meta.label,
 		retriable: meta.retriable,
 		cloudflare: code === 'SOURCE_CLOUDFLARE',
 		expected: meta.expected,
 	}
+}
+
+export function sourceErrorLabel(e: unknown): string {
+	return sourceErrorInfo(e)?.label ?? (errorText(e) || 'Something went wrong')
 }
 
 export function isExpectedSourceNoise(e: unknown): boolean {

--- a/src/lib/server-adapters/tsunagu/trackers.ts
+++ b/src/lib/server-adapters/tsunagu/trackers.ts
@@ -108,6 +108,25 @@ export const trackers = {
 		return data.trackerLogout
 	},
 
+	async createTrackerStub(
+		trackerKey: string,
+		remoteId: string,
+		contentType: ContentType,
+		title: string,
+		coverUrl?: string | null,
+	): Promise<{ id: string }> {
+		const data = await gql<{ createTrackerStub: { id: string } }>(
+			`mutation CreateTrackerStub($trackerKey: String!, $remoteId: String!, $contentType: ContentType!, $title: String!, $coverUrl: String) {
+				createTrackerStub(trackerKey: $trackerKey, remoteId: $remoteId, contentType: $contentType, title: $title, coverUrl: $coverUrl) {
+					id
+				}
+			}`,
+			{ trackerKey, remoteId, contentType, title, coverUrl: coverUrl || null },
+			baseUrl(),
+		)
+		return data.createTrackerStub
+	},
+
 	async bindTrack(mediaId: string, trackerKey: string, remoteId: string): Promise<TrackLink> {
 		const data = await gql<{ bindTrack: TrackLink }>(
 			`mutation BindTrack($mediaId: ID!, $trackerKey: String!, $remoteId: String!) {

--- a/src/lib/server-adapters/tsunagu/trackers.ts
+++ b/src/lib/server-adapters/tsunagu/trackers.ts
@@ -1,5 +1,5 @@
 import { gql, baseUrl } from './gql'
-import type { Tracker, TrackSearchResult, TrackLink, ContentType } from '$lib/server-adapters/types'
+import type { Tracker, TrackSearchResult, TrackLink, ContentType, TrackerLibraryEntry } from '$lib/server-adapters/types'
 
 const TRACKER_FIELDS = `key name configured isLoggedIn authUrl iconUrl username scoreOptions statusOptions { value name animeName }`
 const LINK_FIELDS = `
@@ -69,6 +69,23 @@ export const trackers = {
 			baseUrl(),
 		)
 		return data.trackSearch
+	},
+
+	async trackerLibrary(
+		trackerKey: string,
+		contentType: ContentType,
+		statuses?: string[],
+	): Promise<TrackerLibraryEntry[]> {
+		const data = await gql<{ trackerLibrary: TrackerLibraryEntry[] }>(
+			`query TrackerLibrary($trackerKey: String!, $contentType: ContentType!, $statuses: [String!]) {
+				trackerLibrary(trackerKey: $trackerKey, contentType: $contentType, statuses: $statuses) {
+					remoteId title titleRomaji titleEnglish status progress score coverUrl mediaType url totalChapters
+				}
+			}`,
+			{ trackerKey, contentType, statuses: statuses && statuses.length ? statuses : undefined },
+			baseUrl(),
+		)
+		return data.trackerLibrary
 	},
 
 	async trackerLogin(trackerKey: string, token: string): Promise<Tracker> {

--- a/src/lib/server-adapters/types.ts
+++ b/src/lib/server-adapters/types.ts
@@ -247,6 +247,20 @@ export interface TrackSearchResult {
 	mediaType?: string | null
 }
 
+export interface TrackerLibraryEntry {
+	remoteId: string
+	title: string
+	titleRomaji: string | null
+	titleEnglish: string | null
+	status: string
+	progress: number
+	score: number
+	coverUrl: string | null
+	mediaType: string | null
+	url: string | null
+	totalChapters: number | null
+}
+
 export interface TrackLink {
 	id: string
 	mediaId: string

--- a/src/lib/styles/themes.css
+++ b/src/lib/styles/themes.css
@@ -29,6 +29,7 @@
 }
 
 [data-theme="light"] {
+  color-scheme: light;
   --bg-void:      #d8d4ce;
   --bg-base:      #e2deda;
   --bg-surface:   #ece8e2;


### PR DESCRIPTION
## Summary

Adds an AniList library import modal under **Settings -> Tracking**, allowing users to populate their local Moku library directly from their tracked AniList manga list.

- **Status selection & match flow**: users pick which reading statuses to fetch (Reading, Completed, Planning, etc.) and a default installed source. Titles are queried using dual English and Romaji names against the selected extension to maximize hit rates.
- **Assign table for misses**: unmatched titles stay in an interactive table where users can multi-select and re-search them against other installed sources or skip them.
- **Single-title controls & retries**: individual entries can be retried on demand, reassigned to a specific source, or excluded.
- **Friendly error handling**: maps raw backend/gRPC timeout exceptions (e.g. `DeadlineExceeded`) to clean, human-readable UI labels (`Source timed out`) with hoverable error logs.
- **Non-destructive & persistent**: supports Dry Run mode to preview import candidates without writing to the database; persists in-progress match sessions in `localStorage` so navigation or dialog closure does not lose state.
- **Custom UI controls**: introduces an accessible `.s-check` square checkbox matching the Moku dark design system instead of unstyled native elements.

Closes #36

## Prerequisites

Requires the backend changes from [PR 2](https://github.com/moku-project/Tsunagu/pull/2) exposing `titleRomaji` and `titleEnglish` on `trackerLibrary`.

## Test Plan

- [x] Connect a valid AniList account in Settings -> Tracking.
- [x] Open **Import from AniList**, pick a status (e.g. `Reading`), and select a default source.
(can't continue with tests because i hit 429's x])
- [ ] Verify titles with English/Romaji naming variations resolve properly.
- [ ] Test the **Dry run** toggle; confirm no database entries are created.
- [x] Abort matching via **Stop** / `Esc`, close the modal, reopen, and confirm state restores via **Resume**.
- [x] In the assign table, select unmatched items and trigger a bulk search on an alternate source.
- [x] Verify failed source queries display a readable badge (`Source timed out`) with a retry button instead of a raw gRPC stack trace.
- [ ] Perform a full import and verify titles appear in the **Saved** view with correct track links, progress, and metadata attached